### PR TITLE
Increment version to 0.1.0-beta.2 and remove Argo preferences from renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-prokesch/freelens-argocd-extension",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Freelens Extension for ArgoCD resources",
   "repository": {
     "type": "git",

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -40,7 +40,6 @@ import {
   ArgoSyncMenuItem,
   ArgoTerminateMenuItem,
 } from "./menus";
-import { ArgoPreferenceHint, ArgoPreferenceInput } from "./preferences";
 import { buildClusterPageMenus, buildClusterPages } from "./registration/cluster-registration";
 import {
   createKubeObjectDetailRegistration,
@@ -59,15 +58,7 @@ export default class ArgoRenderer extends Renderer.LensExtension {
     ArgoPreferencesStore.getInstanceOrCreate().loadExtension(this);
   }
 
-  appPreferences = [
-    {
-      title: "Argo Preferences",
-      components: {
-        Input: () => <ArgoPreferenceInput />,
-        Hint: () => <ArgoPreferenceHint />,
-      },
-    },
-  ];
+  appPreferences = [];
 
   kubeObjectDetailItems = [
     createKubeObjectDetailRegistration({


### PR DESCRIPTION
- Updated package version to 0.1.0-beta.2 in package.json.
- Removed ArgoPreferenceHint and ArgoPreferenceInput components from the renderer, resulting in an empty appPreferences array.
