### PR TITLE
Increment version to 0.1.0-beta.2 and remove Argo preferences from renderer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,7 @@
-Copyright (c) 2025 Sebastian Prokesch.
+Copyright (c) 2026 Sebastian Prokesch.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,83 @@
 # Freelens ArgoCD Extension
 
-Freelens extension that adds **Argo** cluster pages: **ArgoCD** views for GitOps workflows (overview, applications, AppProjects, config), **Argo Rollouts** listing and Rollout details, plus placeholder pages for **Argo Workflows** (full UI planned in a later phase).
+[![Freelens](https://img.shields.io/badge/freelens.app-02a7a0?style=flat-square)](https://www.freelens.app)
+[![npm](https://img.shields.io/npm/v/@sebastian-prokesch/freelens-argocd-extension?style=flat-square)](https://www.npmjs.com/package/@sebastian-prokesch/freelens-argocd-extension)
+
+This extension integrates Argo workloads into [Freelens](https://www.freelens.app), with cluster pages and resource details for ArgoCD and Argo Rollouts, plus early Argo Workflows support.
+
+## Beta status
+
+This project is in beta (`0.1.0-beta.2`).
+
+- ArgoCD pages are available for Overview, Applications, ApplicationSets, AppProjects, and Config.
+- Argo Rollouts pages and actions are available for common rollout operations.
+- Argo Workflows pages are present, but still considered early and may evolve quickly.
+
+### Known limitations
+
+- Workflows pages exist, but workflows-specific UX is still in active iteration.
+- Config editing targets known Argo ConfigMaps and Argo-labeled Secrets.
+- Feature behavior depends on cluster RBAC and resource schemas.
+
+## Features
+
+- Argo sidebar hub with grouped sections for ArgoCD, Argo Workflows, and Argo Rollouts.
+- ArgoCD overview and list pages for `Application`, `ApplicationSet`, and `AppProject`.
+- Argo Rollouts pages for `Rollout`, `AnalysisRun`, `Experiment`, `AnalysisTemplate`, and `ClusterAnalysisTemplate`.
+- Argo Workflows pages for `Workflow`, `CronWorkflow`, `WorkflowTemplate`, and `ClusterWorkflowTemplate`.
+- Resource detail drawers for ArgoCD, Rollouts, and Workflows kinds.
+- Context-menu actions:
+  - ArgoCD: sync and terminate.
+  - Rollouts: promote, promote full, promote skip current, promote skip all, abort, retry.
+  - Argo config helpers for `Secret` and `ConfigMap`.
 
 ## Requirements
 
 - Kubernetes >= 1.32
-- Freelens >= 1.9.0
+- Freelens `^1.9.0`
+- Node.js >= 22.16.0 (development/build workflows)
+- pnpm 11.x (`packageManager`: `pnpm@11.1.1`)
 
-## Beta Release
+## Install
 
-### Beta scope
+Install from a release tarball (the npm package install flow is not available yet):
 
-- ArgoCD pages: Overview, Applications, ApplicationSets, AppProjects, and Config.
-- Argo Rollouts: list page and Rollout details.
-- Argo Workflows routes are placeholder pages only in this beta.
+1. Download the latest `.tgz` from the [GitHub Releases page](https://github.com/Sebastian-Prokesch/freelens-argocd-extension/releases).
+2. Open Freelens and go to Extensions (`ctrl`+`shift`+`E` or `cmd`+`shift`+`E`).
+3. Load the downloaded tarball path, or drag and drop the `.tgz` into the Freelens window.
 
-### Known limitations
+## Supported APIs and resources
 
-- Workflows UI is intentionally incomplete and will be expanded after beta feedback.
-- Config editing is focused on known ArgoCD ConfigMaps and Argo-labeled secrets.
-- Behavior still depends on cluster RBAC and resource schema quality.
-
-### Compatibility
-
-- Tested with Freelens `>=1.9.0`.
-- Tested against Kubernetes `>=1.32`.
-- Node.js `>=22.16.0` is required for local build/test workflows.
-
-### Security and permissions notes
-
-- Mutating actions (sync, terminate, rollout actions, config/secret updates) execute with your current cluster identity and are limited by your RBAC permissions.
-- Secret values are submitted via Kubernetes `stringData` and should only be edited by trusted operators.
-- Avoid granting broad write access where read-only access is sufficient for your users.
-
-### Beta install and upgrade
-
-Install from the Extensions catalog (`@sebastian-prokesch/freelens-argocd-extension`) or from a local tarball:
-
-```sh
-pnpm build
-pnpm pack
-```
-
-Then load the generated `.tgz` in Freelens Extensions.
-
-### Beta release checklist
-
-```sh
-pnpm type:check
-pnpm lint:check
-pnpm test:unit
-pnpm test:integration
-pnpm security:check
-```
-
-If config editor behavior changes, verify invalid ConfigMap JSON/value types are rejected in the UI before release.
-
-## Supported ArgoCD resources
-
-- `argoproj.io/v1alpha1`:
-  - `Application`
-  - `ApplicationSet`
-  - `AppProject`
-
-## Supported Argo Rollouts resources
-
-- `argoproj.io/v1alpha1`:
-  - `Rollout` (cluster list page + details drawer)
+- `argoproj.io/v1alpha1`
+  - ArgoCD: `Application`, `ApplicationSet`, `AppProject`
+  - Argo Rollouts: `Rollout`, `AnalysisRun`, `Experiment`, `AnalysisTemplate`, `ClusterAnalysisTemplate`
+  - Argo Workflows: `Workflow`, `CronWorkflow`, `WorkflowTemplate`, `ClusterWorkflowTemplate`
 
 ## Navigation and routes
 
-The sidebar shows a top-level **Argo** entry. Under it:
+The sidebar shows a top-level **Argo** entry.
 
 | Area | Cluster page routes |
 | --- | --- |
 | Landing (hub) | `/argo` |
-| ArgoCD (tabs + standalone pages) | `/argo/argocd`, `/argo/argocd/overview`, `/argo/argocd/applications`, `/argo/argocd/applicationsets`, `/argo/argocd/appprojects`, `/argo/argocd/config` |
-| Argo Workflows (placeholders) | `/argo/workflows`, `/argo/workflows/cron-workflows` |
-| Argo Rollouts | `/argo/rollouts` |
+| ArgoCD | `/argo/argocd`, `/argo/argocd/overview`, `/argo/argocd/applications`, `/argo/argocd/applicationsets`, `/argo/argocd/appprojects`, `/argo/argocd/config` |
+| Argo Workflows | `/argo/workflows`, `/argo/workflows/cron-workflows`, `/argo/workflows/workflow-templates`, `/argo/workflows/cluster-workflow-templates` |
+| Argo Rollouts | `/argo/rollouts/overview`, `/argo/rollouts`, `/argo/rollouts/analysis-runs`, `/argo/rollouts/experiments`, `/argo/rollouts/analysis-templates`, `/argo/rollouts/cluster-analysis-templates` |
 
-**Backward compatibility:** The previous default paths under `/argocd/*` are still registered with the same UI, so old bookmarks and deep links keep working.
+Backward compatibility: legacy `/argocd/*` routes are still registered (`/argocd`, `/argocd/overview`, `/argocd/applications`, `/argocd/applicationsets`, `/argocd/appprojects`, `/argocd/config`) so old bookmarks and deep links continue to work.
 
-## Install
+## Security and permissions
 
-Open Freelens and go to Extensions (`ctrl`+`shift`+`E` or `cmd`+`shift`+`E`), then install `@sebastian-prokesch/freelens-argocd-extension`.
-
-## Adding another Argo product (for contributors)
-
-1. Add route segments in [`src/renderer/routes/argo-routes.ts`](src/renderer/routes/argo-routes.ts).
-2. Add Kubernetes resource types/stores under `src/renderer/k8s/<product>/` (see [`src/renderer/k8s/argocd/`](src/renderer/k8s/argocd/), [`src/renderer/k8s/rollouts/`](src/renderer/k8s/rollouts/), and stubs in [`src/renderer/k8s/workflows/`](src/renderer/k8s/workflows/)).
-3. Add pages, optional details, and context menus under `src/renderer/pages/`, `src/renderer/details/`, `src/renderer/menus/`.
-4. Register cluster pages and sidebar items in [`src/renderer/registration/cluster-registration.tsx`](src/renderer/registration/cluster-registration.tsx) (wired from [`src/renderer/index.tsx`](src/renderer/index.tsx)).
+- Mutating actions run with your current cluster identity and are limited by Kubernetes RBAC.
+- Secret updates are submitted through Kubernetes `stringData`; grant edit access only to trusted operators.
+- Prefer read-only permissions where mutation is not required.
 
 ## Build from source
 
 ### Prerequisites
 
-- Node.js (see `package.json` engines)
-- pnpm (via Corepack recommended)
+- Node.js >= 22.16.0
+- pnpm (Corepack recommended)
 
 ```sh
 corepack install
@@ -113,33 +93,16 @@ pnpm pack
 
 ### Install built extension in Freelens
 
-The tarball for the extension will be placed in the current directory. In
-Freelens, navigate to the Extensions list and provide the path to the tarball
-to be loaded, or drag and drop the extension tarball into the Freelens window.
-After loading for a moment, the extension should appear in the list of enabled
-extensions.
+The tarball is generated in the project root. In Freelens, open Extensions and provide the tarball path, or drag and drop the `.tgz` into the Freelens window.
 
-### Check code statically
+### Static checks
 
 ```sh
+pnpm type:check
 pnpm lint:check
 ```
 
-### Keep SCSS typings in sync
-
-SCSS module typings (`*.module.scss.d.ts`) are generated files. When changing module SCSS:
-
-```sh
-pnpm clean:dts
-pnpm build
-pnpm type:check
-```
-
-Commit regenerated `*.module.scss.d.ts` alongside the SCSS changes.
-
 ### Testing
-
-#### Unit/component tests (Jest + React Testing Library)
 
 ```sh
 pnpm test
@@ -148,41 +111,35 @@ pnpm test:unit
 pnpm test:watch
 ```
 
-#### Integration smoke test (Jest + Playwright + Freelens)
-
-This launches the Freelens desktop app via Playwright, installs the extension, and verifies the ArgoCD overview page renders.
-
-Prerequisites:
-- Build a tarball for the extension:
-
-```sh
-pnpm build
-pnpm pack
-```
-
-- Set required environment variables:
-
-```sh
-# path to the built extension tarball (.tgz) from `pnpm pack`
-export EXTENSION_PATH="/absolute/path/to/<your-extension>.tgz"
-
-# path to the Freelens executable
-# macOS example:
-export FREELENS_EXECUTABLE_PATH="/Applications/Freelens.app/Contents/MacOS/Freelens"
-```
-
-Run:
+Integration smoke test:
 
 ```sh
 pnpm test:integration
 ```
 
-Notes:
-- The integration smoke test is **skipped automatically** if `EXTENSION_PATH` or `FREELENS_EXECUTABLE_PATH` (or equivalents) are not set.
-- The “ArgoCD Overview” UI is a **cluster page**; if Freelens is on the Welcome screen with no active cluster context, the smoke test only validates **launch + install**, and skips the cluster-page assertion.
+The integration smoke test uses Playwright to launch Freelens, install the extension, and validate rendering of the ArgoCD overview page when a cluster context is available.
+
+Set environment variables before running integration tests:
+
+```sh
+# path to the built extension tarball (.tgz)
+export EXTENSION_PATH="/absolute/path/to/<your-extension>.tgz"
+
+# path to the Freelens executable (macOS example)
+export FREELENS_EXECUTABLE_PATH="/Applications/Freelens.app/Contents/MacOS/Freelens"
+```
+
+## Contributing
+
+To add another Argo product:
+
+1. Add route segments in [`src/renderer/routes/argo-routes.ts`](src/renderer/routes/argo-routes.ts).
+2. Add Kubernetes resource types/stores under `src/renderer/k8s/<product>/`.
+3. Add pages, details, and menu items under `src/renderer/pages/`, `src/renderer/details/`, and `src/renderer/menus/`.
+4. Register cluster pages and sidebar entries in [`src/renderer/registration/cluster-registration.tsx`](src/renderer/registration/cluster-registration.tsx), and register related detail/menu items in [`src/renderer/index.tsx`](src/renderer/index.tsx).
 
 ## License
 
-Copyright (c) 2025 Sebastian Prokesch.
+Copyright (c) 2026 Sebastian Prokesch.
 
 [MIT License](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
- Updated package version to 0.1.0-beta.2 in package.json.
- Removed ArgoPreferenceHint and ArgoPreferenceInput components from the renderer, resulting in an empty appPreferences array.
