### PR TITLE
Redact repo URLs and add Argo config loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension integrates Argo workloads into [Freelens](https://www.freelens.ap
 
 ## Beta status
 
-This project is in beta (`0.1.0-beta.2`).
+This project is in beta (`0.1.0-beta.3`).
 
 - ArgoCD pages are available for Overview, Applications, ApplicationSets, AppProjects, and Config.
 - Argo Rollouts pages and actions are available for common rollout operations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-prokesch/freelens-argocd-extension",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Freelens Extension for ArgoCD resources",
   "repository": {
     "type": "git",

--- a/src/renderer/components/argo-config/argo-config-dialog.tsx
+++ b/src/renderer/components/argo-config/argo-config-dialog.tsx
@@ -6,6 +6,7 @@ import {
   ARGOCD_PART_OF_VALUE,
   ARGOCD_SECRET_TYPE_LABEL,
   type ArgoSecretType,
+  getRepoAuthMethod,
   getSecretField,
   type LabeledObject,
 } from "../../k8s/argocd";
@@ -117,28 +118,8 @@ const emptyConfigMapForm = (): ConfigMapFormState => ({
   dataJson: '{\n  "key": "value"\n}',
 });
 
-const getAuthMethod = (secret: LabeledObject | undefined): AuthMethod => {
-  if (!secret) {
-    return "none";
-  }
-
-  if (getSecretField(secret, "sshPrivateKey")) {
-    return "ssh";
-  }
-
-  if (getSecretField(secret, "githubAppPrivateKey") || getSecretField(secret, "githubAppID")) {
-    return "githubApp";
-  }
-
-  if (getSecretField(secret, "username") || getSecretField(secret, "password")) {
-    return "https";
-  }
-
-  return "none";
-};
-
 const loadRepoFormFromSecret = (secret: LabeledObject | undefined): RepoFormState => {
-  const authMethod = getAuthMethod(secret);
+  const authMethod = secret ? getRepoAuthMethod(secret) : "none";
 
   return {
     name: secret?.metadata?.name ?? "",

--- a/src/renderer/details/__tests__/argo-config-details.test.tsx
+++ b/src/renderer/details/__tests__/argo-config-details.test.tsx
@@ -44,6 +44,27 @@ describe("ArgoConfigDetails", () => {
     expect(screen.getByText("HTTPS")).toBeInTheDocument();
   });
 
+  it("redacts userinfo from repository URL in details", () => {
+    const secret = makeObject({
+      metadata: {
+        name: "repo",
+        namespace: "argocd",
+        labels: {
+          "argocd.argoproj.io/secret-type": "repository",
+        },
+      },
+      stringData: {
+        url: "https://user:secrettoken@example.com/org/repo.git",
+        type: "git",
+      },
+    });
+
+    render(<ArgoConfigDetails object={secret as any} extension={extension} />);
+
+    expect(screen.getByText("https://example.com/org/repo.git")).toBeInTheDocument();
+    expect(screen.queryByText("https://user:secrettoken@example.com/org/repo.git")).not.toBeInTheDocument();
+  });
+
   it("renders cluster secret details", () => {
     const secret = makeObject({
       metadata: {

--- a/src/renderer/details/argo-config-details.tsx
+++ b/src/renderer/details/argo-config-details.tsx
@@ -14,6 +14,7 @@ import {
   parseClusterConnection,
   parseRbacPolicyCsv,
   parseRepoConnection,
+  redactUrlUserinfoForDisplay,
   summarizeNotificationsData,
 } from "../k8s/argocd";
 
@@ -70,7 +71,7 @@ const renderSecretDetails = (secret: LabeledObject) => {
       <>
         <DrawerTitle title="ArgoCD Config" />
         <DrawerItem name="Secret Type">{secretType}</DrawerItem>
-        <DrawerItem name="URL">{getSecretField(secret, "url") ?? "N/A"}</DrawerItem>
+        <DrawerItem name="URL">{redactUrlUserinfoForDisplay(getSecretField(secret, "url")) ?? "N/A"}</DrawerItem>
         <DrawerItem name="Host">{connection.host}</DrawerItem>
         <DrawerItem name="Protocol">{connection.protocol}</DrawerItem>
         <DrawerItem name="Type">{connection.repositoryType}</DrawerItem>

--- a/src/renderer/k8s/argocd/__tests__/argo-config-resource-loader.test.ts
+++ b/src/renderer/k8s/argocd/__tests__/argo-config-resource-loader.test.ts
@@ -1,0 +1,85 @@
+import {
+  ARGOCD_CONFIGMAP_LABEL_SELECTOR,
+  ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR,
+  ARGOCD_TYPED_SECRET_LABEL_SELECTOR,
+  getNamespacesForArgoConfigQuery,
+  loadArgoConfigMaps,
+  loadArgoConfigSecrets,
+} from "../argo-config-resource-loader";
+
+describe("argo-config-resource-loader", () => {
+  it("getNamespacesForArgoConfigQuery prefers context namespaces", () => {
+    const store = {
+      contextNamespaces: ["a", "b"],
+      items: [{ getName: () => "ignored" }],
+    };
+
+    expect(getNamespacesForArgoConfigQuery(store)).toEqual(["a", "b"]);
+  });
+
+  it("getNamespacesForArgoConfigQuery falls back to all namespace items", () => {
+    const store = {
+      contextNamespaces: [],
+      items: [{ getName: () => "ns-one" }, { getName: () => "ns-two" }],
+    };
+
+    expect(getNamespacesForArgoConfigQuery(store)).toEqual(["ns-one", "ns-two"]);
+  });
+
+  it("loadArgoConfigSecrets requests typed and notifications lists per namespace", async () => {
+    const list = jest.fn(async ({ namespace }: { namespace: string }, query?: Record<string, string>) => {
+      if (namespace === "one" && query?.labelSelector === ARGOCD_TYPED_SECRET_LABEL_SELECTOR) {
+        return [{ getNs: () => "one", getName: () => "r1", getId: () => "uid-r1" }];
+      }
+
+      if (namespace === "one" && query?.fieldSelector === ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR) {
+        return [{ getNs: () => "one", getName: () => "argocd-notifications-secret", getId: () => "uid-n1" }];
+      }
+
+      if (namespace === "two" && query?.labelSelector === ARGOCD_TYPED_SECRET_LABEL_SELECTOR) {
+        return [{ getNs: () => "two", getName: () => "r2", getId: () => "uid-r2" }];
+      }
+
+      if (namespace === "two" && query?.fieldSelector === ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const secrets = await loadArgoConfigSecrets(["one", "two"], { list });
+
+    expect(list).toHaveBeenCalledTimes(4);
+    expect(secrets).toHaveLength(3);
+    expect(list.mock.calls.filter((c) => c[1]?.labelSelector === ARGOCD_TYPED_SECRET_LABEL_SELECTOR)).toHaveLength(2);
+    expect(
+      list.mock.calls.filter((c) => c[1]?.fieldSelector === ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR),
+    ).toHaveLength(2);
+  });
+
+  it("loadArgoConfigMaps requests part-of label per namespace", async () => {
+    const list = jest.fn(async ({ namespace }: { namespace: string }, query?: Record<string, string>) => {
+      expect(query?.labelSelector).toBe(ARGOCD_CONFIGMAP_LABEL_SELECTOR);
+      return [{ getNs: () => namespace, getName: () => `cm-${namespace}`, getId: () => `id-${namespace}` }];
+    });
+
+    const maps = await loadArgoConfigMaps(["a", "b"], { list });
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(maps).toHaveLength(2);
+  });
+
+  it("dedupes duplicate objects returned from overlapping queries", async () => {
+    const same = { getNs: () => "ns", getName: () => "dup", getId: () => "same-uid" };
+    const list = jest.fn(async (_opts: { namespace: string }, query?: Record<string, string>) => {
+      if (query?.labelSelector) {
+        return [same];
+      }
+
+      return [same];
+    });
+
+    const secrets = await loadArgoConfigSecrets(["ns"], { list });
+    expect(secrets).toHaveLength(1);
+  });
+});

--- a/src/renderer/k8s/argocd/__tests__/argo-config.test.ts
+++ b/src/renderer/k8s/argocd/__tests__/argo-config.test.ts
@@ -18,6 +18,8 @@ import {
   parseClusterConnection,
   parseRbacPolicyCsv,
   parseRepoConnection,
+  redactUrlUserinfoForDisplay,
+  secretHasStringOrDataKey,
   summarizeNotificationsData,
 } from "../argo-config";
 
@@ -202,5 +204,24 @@ describe("argo-config helpers", () => {
     });
     expect(parsedPolicy.parseErrors).toEqual(["invalid-line"]);
     expect(getRepoAuthMethod(makeObject({ stringData: {} }))).toBe("none");
+  });
+
+  it("detects repo auth from data keys without decoding base64 material", () => {
+    const secret = makeObject({
+      data: {
+        sshPrivateKey: Buffer.from("not-actually-read", "utf8").toString("base64"),
+      },
+    });
+
+    expect(secretHasStringOrDataKey(secret, "sshPrivateKey")).toBe(true);
+    expect(getRepoAuthMethod(secret)).toBe("ssh");
+  });
+
+  it("redacts embedded credentials from common URL shapes", () => {
+    expect(redactUrlUserinfoForDisplay("https://user:token@github.com/org/repo.git")).toBe(
+      "https://github.com/org/repo.git",
+    );
+    expect(redactUrlUserinfoForDisplay("https://github.com/plain.git")).toBe("https://github.com/plain.git");
+    expect(redactUrlUserinfoForDisplay(undefined)).toBeUndefined();
   });
 });

--- a/src/renderer/k8s/argocd/argo-config-resource-loader.ts
+++ b/src/renderer/k8s/argocd/argo-config-resource-loader.ts
@@ -1,0 +1,92 @@
+import {
+  ARGOCD_NOTIFICATIONS_SECRET_NAME,
+  ARGOCD_PART_OF_LABEL,
+  ARGOCD_PART_OF_VALUE,
+  ARGOCD_SECRET_TYPE_LABEL,
+} from "./argo-config";
+
+/** ArgoCD repository / repo-creds / cluster secrets always carry this label. */
+export const ARGOCD_TYPED_SECRET_LABEL_SELECTOR = `${ARGOCD_SECRET_TYPE_LABEL} in (repository,repo-creds,cluster)`;
+
+/** Notifications controller secret is identified by name (no Argo secret-type label). */
+export const ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR = `metadata.name=${ARGOCD_NOTIFICATIONS_SECRET_NAME}`;
+
+/** ArgoCD-managed ConfigMaps use the standard part-of label. */
+export const ARGOCD_CONFIGMAP_LABEL_SELECTOR = `${ARGOCD_PART_OF_LABEL}=${ARGOCD_PART_OF_VALUE}`;
+
+export interface NamespaceListableStore {
+  contextNamespaces: string[];
+  items: { getName: () => string }[];
+}
+
+export function getNamespacesForArgoConfigQuery(namespaceStore: NamespaceListableStore): string[] {
+  const fromContext = namespaceStore.contextNamespaces;
+
+  if (fromContext.length > 0) {
+    return [...fromContext];
+  }
+
+  return namespaceStore.items.map((ns) => ns.getName());
+}
+
+export interface ListableKubeApi<T> {
+  list(options: { namespace: string }, query?: { labelSelector?: string; fieldSelector?: string }): Promise<T[] | null>;
+}
+
+const dedupeByObjectId = <
+  T extends { getId?: () => string; metadata?: { uid?: string }; getNs: () => string; getName: () => string },
+>(
+  items: T[],
+): T[] => {
+  const seen = new Set<string>();
+  const out: T[] = [];
+
+  for (const item of items) {
+    const id = item.getId?.() ?? item.metadata?.uid ?? `${item.getNs()}/${item.getName()}`;
+
+    if (seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    out.push(item);
+  }
+
+  return out;
+};
+
+/**
+ * Lists ArgoCD-related Secrets using server-side selectors (per namespace), avoiding a cluster-wide
+ * unfiltered Secret list.
+ */
+export async function loadArgoConfigSecrets<
+  T extends { getId?: () => string; metadata?: { uid?: string }; getNs: () => string; getName: () => string },
+>(namespaces: string[], secretApi: ListableKubeApi<T>): Promise<T[]> {
+  const results = await Promise.all(
+    namespaces.map(async (namespace) => {
+      const [typed, notifications] = await Promise.all([
+        secretApi.list({ namespace }, { labelSelector: ARGOCD_TYPED_SECRET_LABEL_SELECTOR }),
+        secretApi.list({ namespace }, { fieldSelector: ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR }),
+      ]);
+
+      return [...(typed ?? []), ...(notifications ?? [])];
+    }),
+  );
+
+  return dedupeByObjectId(results.flat());
+}
+
+/**
+ * Lists ArgoCD part-of ConfigMaps using a server-side label selector (per namespace).
+ */
+export async function loadArgoConfigMaps<
+  T extends { getId?: () => string; metadata?: { uid?: string }; getNs: () => string; getName: () => string },
+>(namespaces: string[], configMapApi: ListableKubeApi<T>): Promise<T[]> {
+  const results = await Promise.all(
+    namespaces.map(async (namespace) =>
+      configMapApi.list({ namespace }, { labelSelector: ARGOCD_CONFIGMAP_LABEL_SELECTOR }),
+    ),
+  );
+
+  return dedupeByObjectId(results.flat().filter(Boolean) as T[]);
+}

--- a/src/renderer/k8s/argocd/argo-config.ts
+++ b/src/renderer/k8s/argocd/argo-config.ts
@@ -114,6 +114,46 @@ export const decodeBase64 = (value?: string): string | undefined => {
   }
 };
 
+/** True if the key exists in stringData or in opaque data without decoding base64. */
+export const secretHasStringOrDataKey = (secret: LabeledObject, key: string): boolean =>
+  Boolean(secret.stringData?.[key] ?? secret.data?.[key]);
+
+/**
+ * Strips RFC 3986 userinfo from absolute URLs for safe display (avoids leaking embedded credentials).
+ * Non-URL and scp-style strings are returned unchanged.
+ */
+export const redactUrlUserinfoForDisplay = (url: string | undefined): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+
+  const trimmed = url.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const withoutUserinfo = trimmed.replace(/^([a-z][a-z0-9+.-]*:\/\/)([^/?#]+@)/i, "$1");
+
+  if (withoutUserinfo !== trimmed) {
+    return withoutUserinfo;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+
+    if (parsed.username || parsed.password) {
+      parsed.username = "";
+      parsed.password = "";
+      return parsed.toString();
+    }
+  } catch {
+    return trimmed;
+  }
+
+  return trimmed;
+};
+
 export const getSecretField = (secret: LabeledObject, key: string): string | undefined =>
   secret.stringData?.[key] ?? decodeBase64(secret.data?.[key]);
 
@@ -148,15 +188,15 @@ const parseUrl = (value?: string): URL | undefined => {
 };
 
 export const getRepoAuthMethod = (secret: LabeledObject): ParsedRepoConnection["authMethod"] => {
-  if (getSecretField(secret, "sshPrivateKey")) {
+  if (secretHasStringOrDataKey(secret, "sshPrivateKey")) {
     return "ssh";
   }
 
-  if (getSecretField(secret, "githubAppPrivateKey") || getSecretField(secret, "githubAppID")) {
+  if (secretHasStringOrDataKey(secret, "githubAppPrivateKey") || secretHasStringOrDataKey(secret, "githubAppID")) {
     return "githubApp";
   }
 
-  if (getSecretField(secret, "username") || getSecretField(secret, "password")) {
+  if (secretHasStringOrDataKey(secret, "username") || secretHasStringOrDataKey(secret, "password")) {
     return "https";
   }
 

--- a/src/renderer/k8s/argocd/index.ts
+++ b/src/renderer/k8s/argocd/index.ts
@@ -2,3 +2,4 @@ export * from "./applications";
 export * from "./applicationset";
 export * from "./appproject";
 export * from "./argo-config";
+export * from "./argo-config-resource-loader";

--- a/src/renderer/pages/__tests__/argo-config-page.test.tsx
+++ b/src/renderer/pages/__tests__/argo-config-page.test.tsx
@@ -1,5 +1,10 @@
 import { Renderer } from "@freelensapp/extensions";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  ARGOCD_CONFIGMAP_LABEL_SELECTOR,
+  ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR,
+  ARGOCD_TYPED_SECRET_LABEL_SELECTOR,
+} from "../../k8s/argocd/argo-config-resource-loader";
 import { ArgoConfigTabContent } from "../argo-config-page";
 
 const makeObject = (
@@ -17,6 +22,7 @@ const makeObject = (
   stringData: undefined,
   getName: () => name,
   getNs: () => namespace,
+  getId: () => `${namespace}/${name}`,
   getCreationTimestamp: () => "2026-05-12T00:00:00.000Z",
   getSearchFields: () => [name, namespace],
   ...extra,
@@ -36,44 +42,69 @@ describe("ArgoConfigTabContent", () => {
     const secretsStore = Renderer.K8sApi.secretsStore as any;
     const configMapStore = Renderer.K8sApi.configMapStore as any;
 
+    const repoSecret = makeObject(
+      "repo-secret",
+      "argocd",
+      { "argocd.argoproj.io/secret-type": "repository" },
+      {
+        stringData: {
+          type: "git",
+          url: "https://github.com/example/project.git",
+          username: "example-user",
+        },
+      },
+    );
+    const notificationsSecret = makeObject(
+      "argocd-notifications-secret",
+      "argocd",
+      {},
+      {
+        data: { "slack-token": "ZXhhbXBsZQ==" },
+      },
+    );
+    const notificationsCm = makeObject(
+      "argocd-notifications-cm",
+      "argocd",
+      { "app.kubernetes.io/part-of": "argocd" },
+      {
+        data: {
+          "trigger.on-sync-succeeded": "value",
+          "template.app-sync": "value",
+          subscriptions: "- recipients: [slack]",
+        },
+      },
+    );
+
     namespaceStore.items = [{ getName: () => "argocd" }];
+    namespaceStore.contextNamespaces = ["argocd"];
     namespaceStore.loadAll = jest.fn(async () => {});
     namespaceStore.subscribe = jest.fn(() => () => {});
+    namespaceStore.onContextChange = jest.fn(() => () => {});
 
     secretsStore.loadAll = jest.fn(async () => {});
     secretsStore.subscribe = jest.fn(() => () => {});
-    secretsStore.contextItems = [
-      makeObject(
-        "repo-secret",
-        "argocd",
-        { "argocd.argoproj.io/secret-type": "repository" },
-        {
-          stringData: {
-            type: "git",
-            url: "https://github.com/example/project.git",
-            username: "example-user",
-          },
-        },
-      ),
-      makeObject("argocd-notifications-secret", "argocd", {}, { data: { "slack-token": "ZXhhbXBsZQ==" } }),
-    ];
+    secretsStore.api = {
+      list: jest.fn(async (_opts: { namespace: string }, query?: Record<string, string>) => {
+        if (query?.labelSelector === ARGOCD_TYPED_SECRET_LABEL_SELECTOR) {
+          return [repoSecret];
+        }
+
+        if (query?.fieldSelector === ARGOCD_NOTIFICATIONS_SECRET_FIELD_SELECTOR) {
+          return [notificationsSecret];
+        }
+
+        return [];
+      }),
+    };
 
     configMapStore.loadAll = jest.fn(async () => {});
     configMapStore.subscribe = jest.fn(() => () => {});
-    configMapStore.contextItems = [
-      makeObject(
-        "argocd-notifications-cm",
-        "argocd",
-        { "app.kubernetes.io/part-of": "argocd" },
-        {
-          data: {
-            "trigger.on-sync-succeeded": "value",
-            "template.app-sync": "value",
-            subscriptions: "- recipients: [slack]",
-          },
-        },
-      ),
-    ];
+    configMapStore.api = {
+      list: jest.fn(async (_opts: { namespace: string }, query?: Record<string, string>) => {
+        expect(query?.labelSelector).toBe(ARGOCD_CONFIGMAP_LABEL_SELECTOR);
+        return [notificationsCm];
+      }),
+    };
   });
 
   it("renders config tabs and loads rows", async () => {
@@ -83,6 +114,15 @@ describe("ArgoConfigTabContent", () => {
     expect(screen.getByRole("button", { name: "Repositories" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Clusters" })).toBeInTheDocument();
     expect(screen.getAllByTestId("KubeObjectListLayoutRow").length).toBeGreaterThan(0);
+  });
+
+  it("lists secrets with server-side selectors instead of unfiltered loadAll", async () => {
+    const secretsStore = Renderer.K8sApi.secretsStore as any;
+    render(<ArgoConfigTabContent />);
+
+    await waitFor(() => expect(secretsStore.api.list).toHaveBeenCalled());
+    expect(secretsStore.loadAll).not.toHaveBeenCalled();
+    expect(secretsStore.subscribe).not.toHaveBeenCalled();
   });
 
   it("renders notifications resources in notifications tab", async () => {
@@ -105,8 +145,9 @@ describe("ArgoConfigTabContent", () => {
 
     namespaceStore.loadAll = jest.fn(() => deferredNamespaces.promise);
     namespaceStore.subscribe = jest.fn(() => () => {});
-    secretsStore.subscribe = jest.fn(() => () => {});
-    configMapStore.subscribe = jest.fn(() => () => {});
+    namespaceStore.onContextChange = jest.fn(() => () => {});
+    secretsStore.api = { list: jest.fn(async () => []) };
+    configMapStore.api = { list: jest.fn(async () => []) };
 
     const { unmount } = render(<ArgoConfigTabContent />);
     unmount();
@@ -117,7 +158,7 @@ describe("ArgoConfigTabContent", () => {
     });
 
     expect(namespaceStore.subscribe).not.toHaveBeenCalled();
-    expect(secretsStore.subscribe).not.toHaveBeenCalled();
-    expect(configMapStore.subscribe).not.toHaveBeenCalled();
+    expect(secretsStore.api.list).not.toHaveBeenCalled();
+    expect(configMapStore.api.list).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/pages/argo-config-page.tsx
+++ b/src/renderer/pages/argo-config-page.tsx
@@ -1,17 +1,22 @@
 import { Renderer } from "@freelensapp/extensions";
+import { reaction } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
 import { argoConfigDialogStore } from "../components/argo-config";
 import { withErrorPage } from "../components/error-page";
 import {
   getArgoSecretType,
+  getNamespacesForArgoConfigQuery,
   getSecretField,
   isArgoConfigMap,
   isArgoNotificationsConfigMap,
   isArgoNotificationsSecret,
   type LabeledObject,
+  loadArgoConfigMaps,
+  loadArgoConfigSecrets,
   parseClusterConnection,
   parseRepoConnection,
+  redactUrlUserinfoForDisplay,
   summarizeNotificationsData,
 } from "../k8s/argocd";
 import styles from "./argo-config-page.module.scss";
@@ -77,7 +82,7 @@ const renderRepoList = (secrets: any[], title: string) => {
       sortingCallbacks={{
         name: (object) => object.getName(),
         namespace: (object) => object.getNs(),
-        url: (object) => getSecretField(object, "url") ?? "",
+        url: (object) => redactUrlUserinfoForDisplay(getSecretField(object, "url")) ?? "",
         host: (object) => parseRepoConnection(object).host,
         protocol: (object) => parseRepoConnection(object).protocol,
         type: (object) => getSecretField(object, "type") ?? "",
@@ -106,7 +111,7 @@ const renderRepoList = (secrets: any[], title: string) => {
         return [
           <WithTooltip>{object.getName()}</WithTooltip>,
           <WithTooltip>{object.getNs()}</WithTooltip>,
-          <WithTooltip>{getSecretField(object, "url") ?? "N/A"}</WithTooltip>,
+          <WithTooltip>{redactUrlUserinfoForDisplay(getSecretField(object, "url")) ?? "N/A"}</WithTooltip>,
           <WithTooltip>{connection.host}</WithTooltip>,
           <WithTooltip>{connection.protocol}</WithTooltip>,
           <WithTooltip>{getSecretField(object, "type") ?? "N/A"}</WithTooltip>,
@@ -236,13 +241,52 @@ export const ArgoConfigTabContent = observer(() => {
   const [activeTab, setActiveTab] = React.useState<ArgoConfigTab>("repositories");
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [secretItems, setSecretItems] = React.useState<LabeledObject[]>([]);
+  const [configMapItems, setConfigMapItems] = React.useState<LabeledObject[]>([]);
   const watches = React.useRef<(() => void)[]>([]);
+  const loadGeneration = React.useRef(0);
 
   React.useEffect(() => {
     let isMounted = true;
+    const { namespaceStore } = Renderer.K8sApi;
+
+    const loadArgoResources = async (options?: { withLoading?: boolean }) => {
+      const generation = ++loadGeneration.current;
+      const withLoading = options?.withLoading ?? true;
+
+      try {
+        setLoadError(null);
+
+        if (withLoading) {
+          setIsLoaded(false);
+        }
+
+        const namespaces = getNamespacesForArgoConfigQuery(namespaceStore);
+
+        const [secrets, configMaps] = await Promise.all([
+          loadArgoConfigSecrets(namespaces, secretsStore.api),
+          loadArgoConfigMaps(namespaces, configMapStore.api),
+        ]);
+
+        if (!isMounted || generation !== loadGeneration.current) {
+          return;
+        }
+
+        setSecretItems(secrets as LabeledObject[]);
+        setConfigMapItems(configMaps as LabeledObject[]);
+        setIsLoaded(true);
+      } catch (error) {
+        if (!isMounted || generation !== loadGeneration.current) {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : "Failed to load ArgoCD config resources.";
+        setLoadError(message);
+        setIsLoaded(true);
+      }
+    };
 
     (async () => {
-      const { namespaceStore } = Renderer.K8sApi;
       try {
         setLoadError(null);
         setIsLoaded(false);
@@ -251,39 +295,42 @@ export const ArgoConfigTabContent = observer(() => {
           return;
         }
         watches.current.push(namespaceStore.subscribe());
-
-        const namespaces = namespaceStore.items.map((ns) => ns.getName());
-        await Promise.all([secretsStore.loadAll({ namespaces }), configMapStore.loadAll({ namespaces })]);
-        if (!isMounted) {
-          return;
-        }
-
-        watches.current.push(secretsStore.subscribe());
-        watches.current.push(configMapStore.subscribe());
-
-        if (isMounted) {
-          setIsLoaded(true);
-        }
+        await loadArgoResources();
       } catch (error) {
         if (isMounted) {
-          const message = error instanceof Error ? error.message : "Failed to load ArgoCD config resources.";
+          const message = error instanceof Error ? error.message : "Failed to load namespaces.";
           setLoadError(message);
           setIsLoaded(true);
         }
       }
     })();
 
+    const contextDisposer = namespaceStore.onContextChange(() => {
+      void loadArgoResources({ withLoading: false });
+    });
+
+    let wasDialogOpen = argoConfigDialogStore.isOpen;
+    const dialogDisposer = reaction(
+      () => argoConfigDialogStore.isOpen,
+      (isOpen) => {
+        if (wasDialogOpen && !isOpen) {
+          void loadArgoResources({ withLoading: false });
+        }
+
+        wasDialogOpen = isOpen;
+      },
+    );
+
     return () => {
       isMounted = false;
+      contextDisposer();
+      dialogDisposer();
       for (const unsubscribe of watches.current) {
         unsubscribe();
       }
       watches.current = [];
     };
   }, []);
-
-  const secretItems = secretsStore.contextItems as any[];
-  const configMapItems = configMapStore.contextItems as any[];
 
   const repositorySecrets = secretItems.filter((item) => getArgoSecretType(item as LabeledObject) === "repository");
   const repoCredsSecrets = secretItems.filter((item) => getArgoSecretType(item as LabeledObject) === "repo-creds");


### PR DESCRIPTION
Introduce argo-config-resource-loader to query typed Secrets and part-of ConfigMaps per-namespace and dedupe results. Add redactUrlUserinfoForDisplay to avoid leaking embedded credentials and use it in details and list views. Use secretHasStringOrDataKey in getRepoAuthMethod so auth is detected from data keys without decoding base64. Add tests and bump version to 0.1.0-beta.3.