### PR TITLE
standardize ArgoCD mutation safety layer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This extension integrates Argo workloads into [Freelens](https://www.freelens.ap
 
 ## Status
 
-Current release: **`0.1.1`** (stable public release).
-
 - ArgoCD pages are available for Overview, Applications, ApplicationSets, AppProjects, and Config.
 - Argo Rollouts pages and actions are available for common rollout operations.
 - Argo Workflows pages are present, but still considered early and may evolve quickly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-prokesch/freelens-argo-extension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Freelens Extension for Argo resources",
   "repository": {
     "type": "git",

--- a/src/renderer/components/argo-config/__tests__/argo-config-dialog.test.tsx
+++ b/src/renderer/components/argo-config/__tests__/argo-config-dialog.test.tsx
@@ -1,8 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
-import { fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ArgoConfigDialog } from "../argo-config-dialog";
 import { argoConfigDialogStore } from "../argo-config-dialog-store";
+
+const setInputValue = (placeholder: string, value: string) => {
+  fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+};
 
 describe("ArgoConfigDialog", () => {
   beforeEach(() => {
@@ -16,82 +19,78 @@ describe("ArgoConfigDialog", () => {
   });
 
   it("creates repository secret in create mode", async () => {
-    const user = userEvent.setup();
     argoConfigDialogStore.openCreate("repository");
 
     render(<ArgoConfigDialog />);
 
-    await user.type(screen.getByPlaceholderText("Name"), "repo-secret");
-    const namespaceInput = screen.getByPlaceholderText("Namespace");
-    await user.clear(namespaceInput);
-    await user.type(namespaceInput, "argocd");
-    await user.type(screen.getByPlaceholderText("Repository URL"), "https://github.com/example/repo.git");
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    setInputValue("Name", "repo-secret");
+    setInputValue("Namespace", "argocd");
+    setInputValue("Repository URL", "https://github.com/example/repo.git");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(Renderer.K8sApi.secretsStore.create).toHaveBeenCalledWith(
-      { name: "repo-secret", namespace: "argocd" },
-      expect.objectContaining({
-        metadata: expect.objectContaining({
-          name: "repo-secret",
-          namespace: "argocd",
-          labels: { "argocd.argoproj.io/secret-type": "repository" },
+    await waitFor(() =>
+      expect(Renderer.K8sApi.secretsStore.create).toHaveBeenCalledWith(
+        { name: "repo-secret", namespace: "argocd" },
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            name: "repo-secret",
+            namespace: "argocd",
+            labels: { "argocd.argoproj.io/secret-type": "repository" },
+          }),
+          stringData: expect.objectContaining({
+            url: "https://github.com/example/repo.git",
+            type: "git",
+          }),
         }),
-        stringData: expect.objectContaining({
-          url: "https://github.com/example/repo.git",
-          type: "git",
-        }),
-      }),
+      ),
     );
-    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("ArgoCD config saved.");
+    await waitFor(() => expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("ArgoCD config saved."));
   });
 
   it("shows validation error for invalid configmap JSON", async () => {
-    const user = userEvent.setup();
     argoConfigDialogStore.openCreate("configmap");
 
     render(<ArgoConfigDialog />);
 
-    await user.type(screen.getByPlaceholderText("Name"), "argocd-cm");
-    const dataInput = screen.getByPlaceholderText("Data JSON");
-    fireEvent.change(dataInput, { target: { value: "{invalid" } });
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    setInputValue("Name", "argocd-cm");
+    setInputValue("Data JSON", "{invalid");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(Renderer.K8sApi.configMapStore.create).not.toHaveBeenCalled();
-    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("ConfigMap data must be valid JSON.");
+    await waitFor(() => expect(Renderer.K8sApi.configMapStore.create).not.toHaveBeenCalled());
+    await waitFor(() =>
+      expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("ConfigMap data must be valid JSON."),
+    );
   });
 
   it("shows validation error when configmap data values are not strings", async () => {
-    const user = userEvent.setup();
     argoConfigDialogStore.openCreate("configmap");
 
     render(<ArgoConfigDialog />);
 
-    await user.type(screen.getByPlaceholderText("Name"), "argocd-cm");
-    const dataInput = screen.getByPlaceholderText("Data JSON");
-    fireEvent.change(dataInput, { target: { value: '{\n  "enabled": true\n}' } });
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    setInputValue("Name", "argocd-cm");
+    setInputValue("Data JSON", '{\n  "enabled": true\n}');
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(Renderer.K8sApi.configMapStore.create).not.toHaveBeenCalled();
-    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith(
-      'ConfigMap data key "enabled" must have a string value.',
+    await waitFor(() => expect(Renderer.K8sApi.configMapStore.create).not.toHaveBeenCalled());
+    await waitFor(() =>
+      expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith(
+        'ConfigMap data key "enabled" must have a string value.',
+      ),
     );
   });
 
   it("shows save error notification and inline error when request fails", async () => {
-    const user = userEvent.setup();
     (Renderer.K8sApi.secretsStore.create as jest.Mock).mockRejectedValueOnce(new Error("forbidden"));
     argoConfigDialogStore.openCreate("repository");
 
     render(<ArgoConfigDialog />);
 
-    await user.type(screen.getByPlaceholderText("Name"), "repo-secret");
-    const namespaceInput = screen.getByPlaceholderText("Namespace");
-    await user.clear(namespaceInput);
-    await user.type(namespaceInput, "argocd");
-    await user.type(screen.getByPlaceholderText("Repository URL"), "https://github.com/example/repo.git");
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    setInputValue("Name", "repo-secret");
+    setInputValue("Namespace", "argocd");
+    setInputValue("Repository URL", "https://github.com/example/repo.git");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("forbidden");
-    expect(screen.getByText("forbidden")).toBeInTheDocument();
+    await waitFor(() => expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("forbidden"));
+    expect(await screen.findByText("forbidden")).toBeInTheDocument();
   });
 });

--- a/src/renderer/endpoints/__tests__/argo-rollout-endpoints.test.ts
+++ b/src/renderer/endpoints/__tests__/argo-rollout-endpoints.test.ts
@@ -37,40 +37,111 @@ describe("argo-rollout-endpoints", () => {
     });
   });
 
-  it("abortRollout patches rollout with merge strategy", async () => {
+  it("abortRollout patches rollout /status with merge patch content type", async () => {
+    const requestPatch = jest.fn().mockResolvedValue({});
     const patch = jest.fn().mockResolvedValueOnce(undefined);
-    const store = { patch } as any;
-    const rollout = { getName: () => "demo-rollout" } as any;
+    const store = {
+      patch,
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+        request: { patch: requestPatch },
+      },
+    } as any;
+    const rollout = mockRollout();
+
+    await abortRollout(store, rollout);
+
+    expect(requestPatch).toHaveBeenCalledWith(
+      `${rolloutApiUrl}/status`,
+      { data: buildRolloutAbortMergePatch() },
+      expect.objectContaining({
+        headers: { "content-type": "application/merge-patch+json" },
+      }),
+    );
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("retryRollout patches rollout /status with merge patch content type", async () => {
+    const requestPatch = jest.fn().mockResolvedValue({});
+    const patch = jest.fn().mockResolvedValueOnce(undefined);
+    const store = {
+      patch,
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+        request: { patch: requestPatch },
+      },
+    } as any;
+    const rollout = mockRollout();
+
+    await retryRollout(store, rollout);
+
+    expect(requestPatch).toHaveBeenCalledWith(
+      `${rolloutApiUrl}/status`,
+      { data: buildRolloutRetryMergePatch() },
+      expect.objectContaining({
+        headers: { "content-type": "application/merge-patch+json" },
+      }),
+    );
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("abortRollout propagates non-404 /status errors", async () => {
+    const error = new Error("boom");
+    const store = {
+      patch: jest.fn(),
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+        request: { patch: jest.fn().mockRejectedValueOnce(error) },
+      },
+    } as any;
+    const rollout = mockRollout();
+
+    await expect(abortRollout(store, rollout)).rejects.toThrow("boom");
+  });
+
+  it("retryRollout propagates non-404 /status errors", async () => {
+    const error = new Error("boom");
+    const store = {
+      patch: jest.fn(),
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+        request: { patch: jest.fn().mockRejectedValueOnce(error) },
+      },
+    } as any;
+    const rollout = mockRollout();
+
+    await expect(retryRollout(store, rollout)).rejects.toThrow("boom");
+  });
+
+  it("abortRollout falls back to store.patch on 404 /status", async () => {
+    const patch = jest.fn().mockResolvedValue(undefined);
+    const store = {
+      patch,
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+        request: { patch: jest.fn().mockRejectedValueOnce({ code: 404 }) },
+      },
+    } as any;
+    const rollout = mockRollout();
 
     await abortRollout(store, rollout);
 
     expect(patch).toHaveBeenCalledWith(rollout, buildRolloutAbortMergePatch(), "merge");
   });
 
-  it("retryRollout patches rollout with merge strategy", async () => {
-    const patch = jest.fn().mockResolvedValueOnce(undefined);
-    const store = { patch } as any;
-    const rollout = { getName: () => "demo-rollout" } as any;
+  it("retryRollout falls back to store.patch on missing request.patch", async () => {
+    const patch = jest.fn().mockResolvedValue(undefined);
+    const store = {
+      patch,
+      api: {
+        formatUrlForNotListing: () => rolloutApiUrl,
+      },
+    } as any;
+    const rollout = mockRollout();
 
     await retryRollout(store, rollout);
 
     expect(patch).toHaveBeenCalledWith(rollout, buildRolloutRetryMergePatch(), "merge");
-  });
-
-  it("abortRollout propagates patch errors", async () => {
-    const error = new Error("boom");
-    const store = { patch: jest.fn().mockRejectedValueOnce(error) } as any;
-    const rollout = { getName: () => "demo-rollout" } as any;
-
-    await expect(abortRollout(store, rollout)).rejects.toThrow("boom");
-  });
-
-  it("retryRollout propagates patch errors", async () => {
-    const error = new Error("boom");
-    const store = { patch: jest.fn().mockRejectedValueOnce(error) } as any;
-    const rollout = { getName: () => "demo-rollout" } as any;
-
-    await expect(retryRollout(store, rollout)).rejects.toThrow("boom");
   });
 });
 

--- a/src/renderer/endpoints/argo-rollout-endpoints.ts
+++ b/src/renderer/endpoints/argo-rollout-endpoints.ts
@@ -19,11 +19,55 @@ export function buildRolloutRetryMergePatch(): Record<string, unknown> {
 }
 
 export async function abortRollout(store: ArgoRolloutStore, rollout: ArgoRollout): Promise<void> {
-  await store.patch(rollout, buildRolloutAbortMergePatch(), "merge");
+  await patchRolloutStatusWithFallback(store, rollout, buildRolloutAbortMergePatch());
 }
 
 export async function retryRollout(store: ArgoRolloutStore, rollout: ArgoRollout): Promise<void> {
-  await store.patch(rollout, buildRolloutRetryMergePatch(), "merge");
+  await patchRolloutStatusWithFallback(store, rollout, buildRolloutRetryMergePatch());
+}
+
+async function patchRolloutStatusWithFallback(
+  store: ArgoRolloutStore,
+  rollout: ArgoRollout,
+  statusPatch: Record<string, unknown>,
+): Promise<void> {
+  const api = (store.api ?? {}) as unknown as {
+    formatUrlForNotListing?: (desc: { namespace?: string; name: string }) => string;
+    request?: {
+      patch: (url: string, params: { data: unknown }, init?: { headers?: Record<string, string> }) => Promise<unknown>;
+    };
+  };
+
+  const rolloutName = typeof rollout.getName === "function" ? rollout.getName() : undefined;
+
+  if (api.formatUrlForNotListing && api.request?.patch && rolloutName) {
+    const rolloutNamespace =
+      typeof rollout.getNs === "function" ? (rollout.getNs() ?? "") : ((rollout as { metadata?: { namespace?: string } }).metadata?.namespace ?? "");
+    const baseUrl = api.formatUrlForNotListing({
+      namespace: rolloutNamespace,
+      name: rolloutName,
+    });
+
+    try {
+      await api.request.patch(
+        `${baseUrl}/status`,
+        { data: statusPatch },
+        {
+          headers: {
+            "content-type": "application/merge-patch+json",
+          },
+        },
+      );
+
+      return;
+    } catch (error) {
+      if (!isKubeNotFoundError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  await store.patch(rollout, statusPatch, "merge");
 }
 
 export type PromoteMergePatch = Record<string, unknown>;

--- a/src/renderer/endpoints/argo-rollout-endpoints.ts
+++ b/src/renderer/endpoints/argo-rollout-endpoints.ts
@@ -42,7 +42,9 @@ async function patchRolloutStatusWithFallback(
 
   if (api.formatUrlForNotListing && api.request?.patch && rolloutName) {
     const rolloutNamespace =
-      typeof rollout.getNs === "function" ? (rollout.getNs() ?? "") : ((rollout as { metadata?: { namespace?: string } }).metadata?.namespace ?? "");
+      typeof rollout.getNs === "function"
+        ? (rollout.getNs() ?? "")
+        : ((rollout as { metadata?: { namespace?: string } }).metadata?.namespace ?? "");
     const baseUrl = api.formatUrlForNotListing({
       namespace: rolloutNamespace,
       name: rolloutName,

--- a/src/renderer/k8s/rollouts/__tests__/state.test.ts
+++ b/src/renderer/k8s/rollouts/__tests__/state.test.ts
@@ -67,6 +67,28 @@ describe("rollout state helpers", () => {
     expect(canRetryRollout(rollout)).toBe(false);
   });
 
+  it("allows abort when rollout is paused at promotable step", () => {
+    const rollout = {
+      status: {
+        phase: "Paused",
+        pauseConditions: [{ reason: "CanaryPauseStep" }],
+      },
+    } as any;
+
+    expect(canAbortRollout(rollout)).toBe(true);
+  });
+
+  it("allows abort when rollout is paused with analysis pending", () => {
+    const rollout = {
+      status: {
+        phase: "Paused",
+        pauseConditions: [{ reason: "PauseReasonAnalysisRunPending" }],
+      },
+    } as any;
+
+    expect(canAbortRollout(rollout)).toBe(true);
+  });
+
   it("returns empty blue-green traffic tooltip when strategy is not blue-green", () => {
     const rollout = {
       spec: { strategy: { canary: { steps: [] } } },

--- a/src/renderer/k8s/rollouts/state.ts
+++ b/src/renderer/k8s/rollouts/state.ts
@@ -123,7 +123,9 @@ export function getRolloutStateReason(rollout: ArgoRollout): string {
 }
 
 export function canAbortRollout(rollout: ArgoRollout): boolean {
-  return deriveRolloutState(rollout) === "progressing";
+  const state = deriveRolloutState(rollout);
+
+  return state === "progressing" || state === "paused_promotable" || state === "paused_analysis_pending";
 }
 
 export function canRetryRollout(rollout: ArgoRollout): boolean {

--- a/src/renderer/menus/__tests__/argo-rollout-abort.test.tsx
+++ b/src/renderer/menus/__tests__/argo-rollout-abort.test.tsx
@@ -40,6 +40,24 @@ describe("ArgoRolloutAbortMenuItem", () => {
     expect(screen.getByText("Abort")).toBeInTheDocument();
   });
 
+  it("renders when rollout is paused", () => {
+    render(
+      <ArgoRolloutAbortMenuItem
+        object={
+          {
+            status: {
+              phase: "Paused",
+              pauseConditions: [{ reason: "CanaryPauseStep" }],
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    expect(screen.getByText("Abort")).toBeInTheDocument();
+  });
+
   it("confirms and patches rollout when clicked", async () => {
     patchMock.mockResolvedValueOnce(undefined);
     (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);

--- a/src/renderer/menus/__tests__/argo-rollout-abort.test.tsx
+++ b/src/renderer/menus/__tests__/argo-rollout-abort.test.tsx
@@ -1,3 +1,4 @@
+import { Renderer } from "@freelensapp/extensions";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ArgoRolloutAbortMenuItem } from "../argo-rollout-abort";
@@ -15,6 +16,13 @@ jest.mock("../../k8s/rollouts", () => ({
 const extension = { name: "argocd-test-extension" } as any;
 
 describe("ArgoRolloutAbortMenuItem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
   it("renders when rollout is progressing", () => {
     render(
       <ArgoRolloutAbortMenuItem
@@ -32,10 +40,12 @@ describe("ArgoRolloutAbortMenuItem", () => {
     expect(screen.getByText("Abort")).toBeInTheDocument();
   });
 
-  it("patches rollout when clicked", async () => {
+  it("confirms and patches rollout when clicked", async () => {
     patchMock.mockResolvedValueOnce(undefined);
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
     const user = userEvent.setup();
     const object = {
+      getName: () => "demo-rollout",
       status: {
         phase: "Progressing",
       },
@@ -52,5 +62,83 @@ describe("ArgoRolloutAbortMenuItem", () => {
       },
       "merge",
     );
+    expect(Renderer.Component.ConfirmDialog.confirm).toHaveBeenCalledWith({
+      labelOk: "Abort Rollout",
+      message: "Abort rollout demo-rollout? This interrupts the ongoing rollout operation.",
+    });
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Abort requested for demo-rollout");
+  });
+
+  it("does not patch when confirmation is cancelled", async () => {
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(false);
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutAbortMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            status: {
+              phase: "Progressing",
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Abort"));
+
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.ok).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.error).not.toHaveBeenCalled();
+  });
+
+  it("shows endpoint error message on failure", async () => {
+    patchMock.mockRejectedValueOnce(new Error("abort denied"));
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutAbortMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            status: {
+              phase: "Progressing",
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Abort"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("abort denied");
+  });
+
+  it("shows fallback message for non-Error failures", async () => {
+    patchMock.mockRejectedValueOnce({ code: 403 });
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutAbortMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            status: {
+              phase: "Progressing",
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Abort"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to abort rollout.");
   });
 });

--- a/src/renderer/menus/argo-rollout-abort.tsx
+++ b/src/renderer/menus/argo-rollout-abort.tsx
@@ -1,11 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../components/error-page";
 import { abortRollout } from "../endpoints/argo-rollout-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import { type ArgoRollout, canAbortRollout, getArgoRolloutStore } from "../k8s/rollouts";
+import { getAbortRolloutConfirmCopy, runGuardedArgoMutation } from "../mutations";
 
 const {
-  Component: { Icon, MenuItem, Notifications },
+  Component: { Icon, MenuItem },
 } = Renderer;
 
 export interface ArgoRolloutAbortMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoRollout> {
@@ -24,13 +24,15 @@ export const ArgoRolloutAbortMenuItem = (props: ArgoRolloutAbortMenuItemProps) =
 
     const handleAbortRollout = async () => {
       const rolloutName = object.getName?.() ?? object.metadata?.name ?? "rollout";
-      try {
-        await abortRollout(rolloutStore, object);
-        Notifications.ok(`Abort requested for ${rolloutName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to abort rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "destructive",
+        actionLabel: "Abort",
+        resourceName: rolloutName,
+        run: () => abortRollout(rolloutStore, object),
+        successMessage: `Abort requested for ${rolloutName}`,
+        failureFallback: "Failed to abort rollout.",
+        confirm: getAbortRolloutConfirmCopy(rolloutName),
+      });
     };
 
     return (

--- a/src/renderer/mutations/__tests__/guarded-mutation.test.ts
+++ b/src/renderer/mutations/__tests__/guarded-mutation.test.ts
@@ -1,0 +1,111 @@
+import { Renderer } from "@freelensapp/extensions";
+import { runGuardedArgoMutation } from "../guarded-mutation";
+
+describe("runGuardedArgoMutation", () => {
+  beforeEach(() => {
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
+  it("runs destructive mutation when confirmed", async () => {
+    const run = jest.fn().mockResolvedValue(undefined);
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+
+    const result = await runGuardedArgoMutation({
+      risk: "destructive",
+      actionLabel: "Abort",
+      resourceName: "demo-rollout",
+      run,
+      successMessage: "Abort requested for demo-rollout",
+      failureFallback: "Failed to abort rollout.",
+      confirm: {
+        title: "Abort Rollout",
+        message: "Abort rollout demo-rollout? This interrupts the ongoing rollout operation.",
+      },
+    });
+
+    expect(Renderer.Component.ConfirmDialog.confirm).toHaveBeenCalledWith({
+      labelOk: "Abort Rollout",
+      message: "Abort rollout demo-rollout? This interrupts the ongoing rollout operation.",
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Abort requested for demo-rollout");
+    expect(result).toBe("success");
+  });
+
+  it("returns cancelled when destructive confirmation is rejected", async () => {
+    const run = jest.fn().mockResolvedValue(undefined);
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(false);
+
+    const result = await runGuardedArgoMutation({
+      risk: "destructive",
+      actionLabel: "Abort",
+      resourceName: "demo-rollout",
+      run,
+      successMessage: "Abort requested for demo-rollout",
+      failureFallback: "Failed to abort rollout.",
+      confirm: {
+        title: "Abort Rollout",
+        message: "Abort rollout demo-rollout? This interrupts the ongoing rollout operation.",
+      },
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.ok).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.error).not.toHaveBeenCalled();
+    expect(result).toBe("cancelled");
+  });
+
+  it("shows error message from thrown Error", async () => {
+    const run = jest.fn().mockRejectedValue(new Error("abort denied"));
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+
+    const result = await runGuardedArgoMutation({
+      risk: "destructive",
+      actionLabel: "Abort",
+      resourceName: "demo-rollout",
+      run,
+      successMessage: "Abort requested for demo-rollout",
+      failureFallback: "Failed to abort rollout.",
+    });
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("abort denied");
+    expect(result).toBe("error");
+  });
+
+  it("shows fallback for non-Error failures", async () => {
+    const run = jest.fn().mockRejectedValue({ code: 403 });
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+
+    const result = await runGuardedArgoMutation({
+      risk: "destructive",
+      actionLabel: "Abort",
+      resourceName: "demo-rollout",
+      run,
+      successMessage: "Abort requested for demo-rollout",
+      failureFallback: "Failed to abort rollout.",
+    });
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to abort rollout.");
+    expect(result).toBe("error");
+  });
+
+  it("skips confirmation for low risk mutations", async () => {
+    const run = jest.fn().mockResolvedValue(undefined);
+
+    const result = await runGuardedArgoMutation({
+      risk: "low",
+      actionLabel: "Sync",
+      resourceName: "demo-app",
+      run,
+      successMessage: "Sync started for demo-app",
+      failureFallback: "Failed to start sync.",
+    });
+
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Sync started for demo-app");
+    expect(result).toBe("success");
+  });
+});

--- a/src/renderer/mutations/guarded-mutation.ts
+++ b/src/renderer/mutations/guarded-mutation.ts
@@ -1,0 +1,50 @@
+import { Renderer } from "@freelensapp/extensions";
+import { getMutationErrorMessage } from "../endpoints/mutation-errors";
+
+export type MutationRisk = "low" | "destructive";
+
+export type GuardedMutationResult = "cancelled" | "success" | "error";
+
+export interface GuardedMutationConfirm {
+  title: string;
+  message: string;
+}
+
+export interface RunGuardedArgoMutationOptions {
+  risk: MutationRisk;
+  actionLabel: string;
+  resourceName: string;
+  run: () => Promise<void>;
+  successMessage: string;
+  failureFallback: string;
+  confirm?: GuardedMutationConfirm;
+}
+
+const {
+  Component: { ConfirmDialog, Notifications },
+} = Renderer;
+
+export async function runGuardedArgoMutation(options: RunGuardedArgoMutationOptions): Promise<GuardedMutationResult> {
+  const { risk, run, successMessage, failureFallback, confirm } = options;
+
+  if (risk === "destructive") {
+    const isConfirmed = await ConfirmDialog.confirm({
+      labelOk: confirm?.title ?? options.actionLabel,
+      message:
+        confirm?.message ?? `${options.actionLabel} ${options.resourceName}? This action has operational impact.`,
+    });
+
+    if (!isConfirmed) {
+      return "cancelled";
+    }
+  }
+
+  try {
+    await run();
+    Notifications.ok(successMessage);
+    return "success";
+  } catch (error) {
+    Notifications.error(getMutationErrorMessage(error, failureFallback));
+    return "error";
+  }
+}

--- a/src/renderer/mutations/index.ts
+++ b/src/renderer/mutations/index.ts
@@ -1,0 +1,2 @@
+export * from "./guarded-mutation";
+export * from "./mutation-copy";

--- a/src/renderer/mutations/mutation-copy.ts
+++ b/src/renderer/mutations/mutation-copy.ts
@@ -1,0 +1,8 @@
+import type { GuardedMutationConfirm } from "./guarded-mutation";
+
+export function getAbortRolloutConfirmCopy(rolloutName: string): GuardedMutationConfirm {
+  return {
+    title: "Abort Rollout",
+    message: `Abort rollout ${rolloutName}? This interrupts the ongoing rollout operation.`,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared renderer mutation helper that standardizes destructive confirmation, mutation execution, and success/failure notifications
- add mutation copy helpers and focused unit tests for confirm, cancel, success, and failure paths
- migrate the rollout abort action as the pilot integration with new confirm/cancel/error coverage

