### PR TITLE
Add Application refresh actions and standardize mutation handlers on guarded flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pre-release builds remain available on npm as `@sebastian-prokesch/freelens-argo
 - Argo Workflows pages for `Workflow`, `CronWorkflow`, `WorkflowTemplate`, and `ClusterWorkflowTemplate`.
 - Resource detail drawers for ArgoCD, Rollouts, and Workflows kinds.
 - Context-menu actions:
-  - ArgoCD: sync and terminate.
+  - ArgoCD: refresh, hard refresh, sync, and terminate.
   - Rollouts: promote, promote full, promote skip current, promote skip all, abort, retry.
   - Argo config helpers for `Secret` and `ConfigMap`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-prokesch/freelens-argo-extension",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Freelens Extension for Argo resources",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebastian-prokesch/freelens-argo-extension",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Freelens Extension for Argo resources",
   "repository": {
     "type": "git",

--- a/src/renderer/__tests__/argo-renderer-registration.test.ts
+++ b/src/renderer/__tests__/argo-renderer-registration.test.ts
@@ -115,11 +115,11 @@ describe("ArgoRenderer registrations", () => {
     expect(detailKinds).toContain("ClusterWorkflowTemplate");
   });
 
-  it("registers sync and terminate menu items for applications", () => {
+  it("registers refresh, hard refresh, sync and terminate menu items for applications", () => {
     const renderer = createRenderer();
     const applicationMenuItems = renderer.kubeObjectMenuItems.filter((item: any) => item.kind === "Application");
 
-    expect(applicationMenuItems.length).toBeGreaterThanOrEqual(2);
+    expect(applicationMenuItems.length).toBeGreaterThanOrEqual(4);
   });
 
   it("registers promote, abort and retry menu items for rollouts", () => {

--- a/src/renderer/components/argo-config/__tests__/argo-config-dialog.test.tsx
+++ b/src/renderer/components/argo-config/__tests__/argo-config-dialog.test.tsx
@@ -93,4 +93,21 @@ describe("ArgoConfigDialog", () => {
     await waitFor(() => expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("forbidden"));
     expect(await screen.findByText("forbidden")).toBeInTheDocument();
   });
+
+  it("shows fallback save error notification and inline error for non-Error failures", async () => {
+    (Renderer.K8sApi.secretsStore.create as jest.Mock).mockRejectedValueOnce({ code: 403 });
+    argoConfigDialogStore.openCreate("repository");
+
+    render(<ArgoConfigDialog />);
+
+    setInputValue("Name", "repo-secret");
+    setInputValue("Namespace", "argocd");
+    setInputValue("Repository URL", "https://github.com/example/repo.git");
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to save ArgoCD config."),
+    );
+    expect(await screen.findByText("Failed to save ArgoCD config.")).toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/argo-config/argo-config-dialog.tsx
+++ b/src/renderer/components/argo-config/argo-config-dialog.tsx
@@ -7,7 +7,6 @@ import {
   updateArgoSecretConfig,
   updateConfigMapConfig,
 } from "../../endpoints/argo-config-endpoints";
-import { getMutationErrorMessage } from "../../endpoints/mutation-errors";
 import {
   ARGOCD_PART_OF_LABEL,
   ARGOCD_PART_OF_VALUE,
@@ -16,12 +15,13 @@ import {
   getSecretField,
   type LabeledObject,
 } from "../../k8s/argocd";
+import { runGuardedArgoMutation } from "../../mutations";
 import styles from "./argo-config-dialog.module.scss";
 import stylesInline from "./argo-config-dialog.module.scss?inline";
 import { type ArgoConfigKind, argoConfigDialogStore } from "./argo-config-dialog-store";
 
 const {
-  Component: { Button, Dialog, Input, Notifications },
+  Component: { Button, Dialog, Input },
   K8sApi: { configMapStore, secretsStore },
 } = Renderer;
 
@@ -281,86 +281,89 @@ export const ArgoConfigDialog = observer(() => {
   const closeDialog = () => argoConfigDialogStore.close();
 
   const handleSave = async () => {
-    try {
-      setError(undefined);
+    setError(undefined);
 
-      if (target.kind === "configmap") {
-        ensureRequiredField(configMapForm.name, "Name");
-        ensureRequiredField(configMapForm.namespace, "Namespace");
-      }
-
-      if (target.kind === "cluster") {
-        ensureRequiredField(clusterForm.name, "Secret name");
-        ensureRequiredField(clusterForm.namespace, "Namespace");
-      }
-
-      if (target.kind === "repository" || target.kind === "repo-creds") {
-        ensureRequiredField(repoForm.name, "Name");
-        ensureRequiredField(repoForm.namespace, "Namespace");
-      }
-
-      if (target.kind === "configmap") {
-        parseConfigMapData(configMapForm.dataJson);
-      }
-
-      if (target.kind === "cluster") {
-        parseJsonObject(clusterForm.configJson, "Cluster config");
-      }
-
-      if (target.kind === "configmap") {
-        const data = parseConfigMapData(configMapForm.dataJson);
-        const name = configMapForm.name.trim();
-        const namespace = configMapForm.namespace.trim();
-        const labels = {
-          ...(target.object?.metadata?.labels ?? {}),
-          [ARGOCD_PART_OF_LABEL]: ARGOCD_PART_OF_VALUE,
-        };
-        if (mode === "create") {
-          await createConfigMapConfig(configMapStore as any, {
-            name,
-            namespace,
-            labels,
-            data,
-          });
-        } else if (target.object) {
-          await updateConfigMapConfig(configMapStore as any, target.object, {
-            name,
-            namespace,
-            labels,
-            data,
-          });
+    await runGuardedArgoMutation({
+      risk: "low",
+      actionLabel: mode === "create" ? "Create ArgoCD Config" : "Save ArgoCD Config",
+      resourceName: target.kind,
+      run: async () => {
+        if (target.kind === "configmap") {
+          ensureRequiredField(configMapForm.name, "Name");
+          ensureRequiredField(configMapForm.namespace, "Namespace");
         }
-      }
 
-      if (target.kind === "repository" || target.kind === "repo-creds" || target.kind === "cluster") {
-        const stringData = buildSecretStringData(target.kind === "cluster" ? clusterForm : repoForm, target.kind);
-        const name = target.kind === "cluster" ? clusterForm.name.trim() : repoForm.name.trim();
-        const namespace = target.kind === "cluster" ? clusterForm.namespace.trim() : repoForm.namespace.trim();
-
-        if (mode === "create") {
-          await createArgoSecretConfig(secretsStore as any, {
-            name,
-            namespace,
-            secretType: target.kind,
-            stringData,
-          });
-        } else if (target.object) {
-          await updateArgoSecretConfig(secretsStore as any, target.object, {
-            name,
-            namespace,
-            secretType: target.kind,
-            stringData,
-          });
+        if (target.kind === "cluster") {
+          ensureRequiredField(clusterForm.name, "Secret name");
+          ensureRequiredField(clusterForm.namespace, "Namespace");
         }
-      }
 
-      closeDialog();
-      Notifications.ok("ArgoCD config saved.");
-    } catch (err) {
-      const message = getMutationErrorMessage(err, "Failed to save ArgoCD config.");
-      setError(message);
-      Notifications.error(message);
-    }
+        if (target.kind === "repository" || target.kind === "repo-creds") {
+          ensureRequiredField(repoForm.name, "Name");
+          ensureRequiredField(repoForm.namespace, "Namespace");
+        }
+
+        if (target.kind === "configmap") {
+          parseConfigMapData(configMapForm.dataJson);
+        }
+
+        if (target.kind === "cluster") {
+          parseJsonObject(clusterForm.configJson, "Cluster config");
+        }
+
+        if (target.kind === "configmap") {
+          const data = parseConfigMapData(configMapForm.dataJson);
+          const name = configMapForm.name.trim();
+          const namespace = configMapForm.namespace.trim();
+          const labels = {
+            ...(target.object?.metadata?.labels ?? {}),
+            [ARGOCD_PART_OF_LABEL]: ARGOCD_PART_OF_VALUE,
+          };
+          if (mode === "create") {
+            await createConfigMapConfig(configMapStore as any, {
+              name,
+              namespace,
+              labels,
+              data,
+            });
+          } else if (target.object) {
+            await updateConfigMapConfig(configMapStore as any, target.object, {
+              name,
+              namespace,
+              labels,
+              data,
+            });
+          }
+        }
+
+        if (target.kind === "repository" || target.kind === "repo-creds" || target.kind === "cluster") {
+          const stringData = buildSecretStringData(target.kind === "cluster" ? clusterForm : repoForm, target.kind);
+          const name = target.kind === "cluster" ? clusterForm.name.trim() : repoForm.name.trim();
+          const namespace = target.kind === "cluster" ? clusterForm.namespace.trim() : repoForm.namespace.trim();
+
+          if (mode === "create") {
+            await createArgoSecretConfig(secretsStore as any, {
+              name,
+              namespace,
+              secretType: target.kind,
+              stringData,
+            });
+          } else if (target.object) {
+            await updateArgoSecretConfig(secretsStore as any, target.object, {
+              name,
+              namespace,
+              secretType: target.kind,
+              stringData,
+            });
+          }
+        }
+
+        closeDialog();
+      },
+      successMessage: "ArgoCD config saved.",
+      failureFallback: "Failed to save ArgoCD config.",
+      onErrorMessage: (message) => setError(message),
+    });
   };
 
   const title = (() => {

--- a/src/renderer/details/__tests__/argo-rollout-details.test.tsx
+++ b/src/renderer/details/__tests__/argo-rollout-details.test.tsx
@@ -36,6 +36,7 @@ describe("ArgoRolloutDetails", () => {
     patchMock.mockClear();
     requestPatchMock.mockClear();
     requestPatchMock.mockResolvedValue({});
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
     (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
     (Renderer.Component.Notifications.error as jest.Mock).mockReset();
   });
@@ -145,7 +146,10 @@ describe("ArgoRolloutDetails", () => {
     expect(screen.queryByRole("button", { name: "Promote" })).not.toBeInTheDocument();
   });
 
-  it("shows abort button for progressing rollout and triggers patch", () => {
+  it("shows abort button for progressing rollout and triggers patch", async () => {
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
+    const user = userEvent.setup();
+
     render(
       <MemoryRouter>
         <ArgoRolloutDetails
@@ -164,7 +168,7 @@ describe("ArgoRolloutDetails", () => {
     const abortButton = screen.getByRole("button", { name: "Abort" });
     expect(abortButton).toBeInTheDocument();
 
-    fireEvent.click(abortButton);
+    await user.click(abortButton);
 
     expect(getPromoteMocks().patchMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -173,6 +177,10 @@ describe("ArgoRolloutDetails", () => {
       },
       "merge",
     );
+    expect(Renderer.Component.ConfirmDialog.confirm).toHaveBeenCalledWith({
+      labelOk: "Abort Rollout",
+      message: "Abort rollout rollout? This interrupts the ongoing rollout operation.",
+    });
   });
 
   it("shows retry button for degraded rollout and triggers patch", () => {
@@ -209,6 +217,7 @@ describe("ArgoRolloutDetails", () => {
   it("shows abort error notification when abort request fails", async () => {
     const { patchMock } = getPromoteMocks();
     patchMock.mockRejectedValueOnce(new Error("abort denied"));
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(true);
     const user = userEvent.setup();
 
     render(
@@ -229,5 +238,33 @@ describe("ArgoRolloutDetails", () => {
     await user.click(screen.getByRole("button", { name: "Abort" }));
 
     expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("abort denied");
+  });
+
+  it("does not patch when abort confirmation is cancelled", async () => {
+    const { patchMock } = getPromoteMocks();
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockResolvedValueOnce(false);
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <ArgoRolloutDetails
+          extension={extension}
+          object={
+            {
+              getName: () => "demo-rollout",
+              status: {
+                phase: "Progressing",
+              },
+            } as any
+          }
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Abort" }));
+
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.ok).not.toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.error).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/details/argo-rollout-details.tsx
+++ b/src/renderer/details/argo-rollout-details.tsx
@@ -5,7 +5,6 @@ import { Link } from "react-router-dom";
 import { withErrorPage } from "../components/error-page";
 import { ConditionsList, ResourceEventsSection, StatusBadge } from "../components/shared";
 import { abortRollout, requestRolloutPromotion, retryRollout } from "../endpoints/argo-rollout-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import {
   type ArgoAnalysisRun,
   type ArgoRollout,
@@ -25,10 +24,11 @@ import {
   getRolloutStateReason,
   getRolloutStrategyLabel,
 } from "../k8s/rollouts";
+import { getAbortRolloutConfirmCopy, runGuardedArgoMutation } from "../mutations";
 import { formatOptionalValue } from "../utils";
 
 const {
-  Component: { Button, DrawerItem, DrawerTitle, Gutter, Notifications, WithTooltip },
+  Component: { Button, DrawerItem, DrawerTitle, Gutter, WithTooltip },
   Navigation: { getDetailsUrl },
 } = Renderer;
 
@@ -90,63 +90,70 @@ export const ArgoRolloutDetails = observer((props: ArgoRolloutDetailsProps) => {
     const rolloutDisplayName = object.getName?.() ?? object.metadata?.name ?? "rollout";
 
     const promoteRollout = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, {});
-        Notifications.ok(`Promote requested for ${rolloutDisplayName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to promote rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Promote",
+        resourceName: rolloutDisplayName,
+        run: () => requestRolloutPromotion(rolloutStore, object, {}),
+        successMessage: `Promote requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to promote rollout.",
+      });
     };
 
     const promoteFullRollout = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { full: true });
-        Notifications.ok(`Full promote requested for ${rolloutDisplayName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to fully promote rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Promote Full",
+        resourceName: rolloutDisplayName,
+        run: () => requestRolloutPromotion(rolloutStore, object, { full: true }),
+        successMessage: `Full promote requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to fully promote rollout.",
+      });
     };
 
     const promoteSkipCurrentRollout = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { skipCurrentStep: true });
-        Notifications.ok(`Skip current step requested for ${rolloutDisplayName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to skip current step.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Skip Current Step",
+        resourceName: rolloutDisplayName,
+        run: () => requestRolloutPromotion(rolloutStore, object, { skipCurrentStep: true }),
+        successMessage: `Skip current step requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to skip current step.",
+      });
     };
 
     const promoteSkipAllRollout = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { skipAllSteps: true });
-        Notifications.ok(`Skip all steps requested for ${rolloutDisplayName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to skip all steps.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Skip All Steps",
+        resourceName: rolloutDisplayName,
+        run: () => requestRolloutPromotion(rolloutStore, object, { skipAllSteps: true }),
+        successMessage: `Skip all steps requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to skip all steps.",
+      });
     };
 
     const handleAbortRollout = async () => {
-      try {
-        await abortRollout(rolloutStore, object);
-        Notifications.ok(`Abort requested for ${object.getName?.() ?? object.metadata?.name ?? "rollout"}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to abort rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "destructive",
+        actionLabel: "Abort",
+        resourceName: rolloutDisplayName,
+        run: () => abortRollout(rolloutStore, object),
+        successMessage: `Abort requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to abort rollout.",
+        confirm: getAbortRolloutConfirmCopy(rolloutDisplayName),
+      });
     };
 
     const handleRetryRollout = async () => {
-      try {
-        await retryRollout(rolloutStore, object);
-        Notifications.ok(`Retry requested for ${object.getName?.() ?? object.metadata?.name ?? "rollout"}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to retry rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Retry",
+        resourceName: rolloutDisplayName,
+        run: () => retryRollout(rolloutStore, object),
+        successMessage: `Retry requested for ${rolloutDisplayName}`,
+        failureFallback: "Failed to retry rollout.",
+      });
     };
 
     return (

--- a/src/renderer/endpoints/__tests__/argo-application-endpoints.test.ts
+++ b/src/renderer/endpoints/__tests__/argo-application-endpoints.test.ts
@@ -1,6 +1,11 @@
 import {
+  ARGO_APPLICATION_REFRESH_ANNOTATION,
+  buildApplicationRefreshMergePatch,
   buildApplicationSyncMergePatch,
   buildApplicationTerminateJsonPatch,
+  hardRefreshApplication,
+  refreshApplication,
+  requestApplicationRefresh,
   syncApplication,
   terminateApplicationOperation,
 } from "../argo-application-endpoints";
@@ -25,6 +30,26 @@ describe("argo-application-endpoints", () => {
     expect(buildApplicationTerminateJsonPatch()).toEqual([{ op: "remove", path: "/operation" }]);
   });
 
+  it("buildApplicationRefreshMergePatch returns normal refresh annotation payload", () => {
+    expect(buildApplicationRefreshMergePatch("normal")).toEqual({
+      metadata: {
+        annotations: {
+          [ARGO_APPLICATION_REFRESH_ANNOTATION]: "normal",
+        },
+      },
+    });
+  });
+
+  it("buildApplicationRefreshMergePatch returns hard refresh annotation payload", () => {
+    expect(buildApplicationRefreshMergePatch("hard")).toEqual({
+      metadata: {
+        annotations: {
+          [ARGO_APPLICATION_REFRESH_ANNOTATION]: "hard",
+        },
+      },
+    });
+  });
+
   it("syncApplication patches application using merge strategy", async () => {
     const patch = jest.fn().mockResolvedValueOnce(undefined);
     const store = { patch } as any;
@@ -45,6 +70,36 @@ describe("argo-application-endpoints", () => {
     expect(patch).toHaveBeenCalledWith(application, buildApplicationTerminateJsonPatch(), "json");
   });
 
+  it("requestApplicationRefresh patches application using merge strategy for chosen mode", async () => {
+    const patch = jest.fn().mockResolvedValueOnce(undefined);
+    const store = { patch } as any;
+    const application = { getName: () => "demo-app" } as any;
+
+    await requestApplicationRefresh(store, application, "normal");
+
+    expect(patch).toHaveBeenCalledWith(application, buildApplicationRefreshMergePatch("normal"), "merge");
+  });
+
+  it("refreshApplication patches with normal refresh annotation", async () => {
+    const patch = jest.fn().mockResolvedValueOnce(undefined);
+    const store = { patch } as any;
+    const application = { getName: () => "demo-app" } as any;
+
+    await refreshApplication(store, application);
+
+    expect(patch).toHaveBeenCalledWith(application, buildApplicationRefreshMergePatch("normal"), "merge");
+  });
+
+  it("hardRefreshApplication patches with hard refresh annotation", async () => {
+    const patch = jest.fn().mockResolvedValueOnce(undefined);
+    const store = { patch } as any;
+    const application = { getName: () => "demo-app" } as any;
+
+    await hardRefreshApplication(store, application);
+
+    expect(patch).toHaveBeenCalledWith(application, buildApplicationRefreshMergePatch("hard"), "merge");
+  });
+
   it("syncApplication propagates patch errors", async () => {
     const error = new Error("boom");
     const store = { patch: jest.fn().mockRejectedValueOnce(error) } as any;
@@ -59,5 +114,13 @@ describe("argo-application-endpoints", () => {
     const application = { getName: () => "demo-app" } as any;
 
     await expect(terminateApplicationOperation(store, application)).rejects.toThrow("boom");
+  });
+
+  it("requestApplicationRefresh propagates patch errors", async () => {
+    const error = new Error("boom");
+    const store = { patch: jest.fn().mockRejectedValueOnce(error) } as any;
+    const application = { getName: () => "demo-app" } as any;
+
+    await expect(requestApplicationRefresh(store, application, "hard")).rejects.toThrow("boom");
   });
 });

--- a/src/renderer/endpoints/argo-application-endpoints.ts
+++ b/src/renderer/endpoints/argo-application-endpoints.ts
@@ -1,5 +1,9 @@
 import type { ArgoApplication, ArgoApplicationStore } from "../k8s/argocd/applications";
 
+export const ARGO_APPLICATION_REFRESH_ANNOTATION = "argocd.argoproj.io/refresh";
+
+export type ApplicationRefreshMode = "normal" | "hard";
+
 /**
  * Endpoint layer owns Argo mutation payloads and request execution.
  * K8s modules continue owning resource and store definitions.
@@ -28,8 +32,34 @@ export function buildApplicationTerminateJsonPatch(): JsonPatchOperation[] {
   return [{ op: "remove", path: "/operation" }];
 }
 
+export function buildApplicationRefreshMergePatch(mode: ApplicationRefreshMode): Record<string, unknown> {
+  return {
+    metadata: {
+      annotations: {
+        [ARGO_APPLICATION_REFRESH_ANNOTATION]: mode,
+      },
+    },
+  };
+}
+
 export async function syncApplication(store: ArgoApplicationStore, application: ArgoApplication): Promise<void> {
   await store.patch(application, buildApplicationSyncMergePatch(), "merge");
+}
+
+export async function requestApplicationRefresh(
+  store: ArgoApplicationStore,
+  application: ArgoApplication,
+  mode: ApplicationRefreshMode,
+): Promise<void> {
+  await store.patch(application, buildApplicationRefreshMergePatch(mode), "merge");
+}
+
+export async function refreshApplication(store: ArgoApplicationStore, application: ArgoApplication): Promise<void> {
+  await requestApplicationRefresh(store, application, "normal");
+}
+
+export async function hardRefreshApplication(store: ArgoApplicationStore, application: ArgoApplication): Promise<void> {
+  await requestApplicationRefresh(store, application, "hard");
 }
 
 export async function terminateApplicationOperation(

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -31,6 +31,8 @@ import {
 import { ArgoClusterWorkflowTemplate, ArgoCronWorkflow, ArgoWorkflow, ArgoWorkflowTemplate } from "./k8s/workflows";
 import {
   ArgoConfigMenuItem,
+  ArgoHardRefreshMenuItem,
+  ArgoRefreshMenuItem,
   ArgoRolloutAbortMenuItem,
   ArgoRolloutPromoteFullMenuItem,
   ArgoRolloutPromoteMenuItem,
@@ -154,6 +156,18 @@ export default class ArgoRenderer extends Renderer.LensExtension {
   clusterPageMenus = buildClusterPageMenus();
 
   kubeObjectMenuItems = [
+    createKubeObjectMenuRegistration({
+      kind: ArgoApplication.kind,
+      apiVersions: ArgoApplication.crd.apiVersions,
+      extension: this,
+      MenuItem: ArgoRefreshMenuItem,
+    }),
+    createKubeObjectMenuRegistration({
+      kind: ArgoApplication.kind,
+      apiVersions: ArgoApplication.crd.apiVersions,
+      extension: this,
+      MenuItem: ArgoHardRefreshMenuItem,
+    }),
     createKubeObjectMenuRegistration({
       kind: ArgoApplication.kind,
       apiVersions: ArgoApplication.crd.apiVersions,

--- a/src/renderer/menus/__tests__/argo-application-refresh.test.tsx
+++ b/src/renderer/menus/__tests__/argo-application-refresh.test.tsx
@@ -1,0 +1,140 @@
+import { Renderer } from "@freelensapp/extensions";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ArgoHardRefreshMenuItem, ArgoRefreshMenuItem } from "../argo-application-refresh";
+
+const patchMock = jest.fn();
+
+jest.mock("../../k8s/argocd", () => ({
+  getArgoApplicationStore: () => ({
+    patch: patchMock,
+  }),
+}));
+
+const extension = { name: "argocd-test-extension" } as any;
+
+describe("ArgoRefreshMenuItem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
+  it("renders refresh action for application", () => {
+    render(<ArgoRefreshMenuItem object={{} as any} extension={extension} />);
+
+    expect(screen.getByText("Refresh")).toBeInTheDocument();
+  });
+
+  it("patches refresh annotation when clicked", async () => {
+    patchMock.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    const object = {
+      getName: () => "demo-app",
+    } as any;
+
+    render(<ArgoRefreshMenuItem object={object} extension={extension} />);
+
+    await user.click(screen.getByText("Refresh"));
+
+    expect(patchMock).toHaveBeenCalledWith(
+      object,
+      {
+        metadata: {
+          annotations: {
+            "argocd.argoproj.io/refresh": "normal",
+          },
+        },
+      },
+      "merge",
+    );
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Refresh requested for demo-app");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows endpoint error message when refresh fails", async () => {
+    patchMock.mockRejectedValueOnce(new Error("refresh denied"));
+    const user = userEvent.setup();
+
+    render(<ArgoRefreshMenuItem object={{ getName: () => "demo-app" } as any} extension={extension} />);
+
+    await user.click(screen.getByText("Refresh"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("refresh denied");
+  });
+
+  it("shows fallback error message when refresh fails with non-Error", async () => {
+    patchMock.mockRejectedValueOnce({ code: 403 });
+    const user = userEvent.setup();
+
+    render(<ArgoRefreshMenuItem object={{ getName: () => "demo-app" } as any} extension={extension} />);
+
+    await user.click(screen.getByText("Refresh"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to refresh application.");
+  });
+});
+
+describe("ArgoHardRefreshMenuItem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
+  it("renders hard refresh action for application", () => {
+    render(<ArgoHardRefreshMenuItem object={{} as any} extension={extension} />);
+
+    expect(screen.getByText("Hard Refresh")).toBeInTheDocument();
+  });
+
+  it("patches hard refresh annotation when clicked", async () => {
+    patchMock.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    const object = {
+      getName: () => "demo-app",
+    } as any;
+
+    render(<ArgoHardRefreshMenuItem object={object} extension={extension} />);
+
+    await user.click(screen.getByText("Hard Refresh"));
+
+    expect(patchMock).toHaveBeenCalledWith(
+      object,
+      {
+        metadata: {
+          annotations: {
+            "argocd.argoproj.io/refresh": "hard",
+          },
+        },
+      },
+      "merge",
+    );
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Hard refresh requested for demo-app");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows endpoint error message when hard refresh fails", async () => {
+    patchMock.mockRejectedValueOnce(new Error("hard refresh denied"));
+    const user = userEvent.setup();
+
+    render(<ArgoHardRefreshMenuItem object={{ getName: () => "demo-app" } as any} extension={extension} />);
+
+    await user.click(screen.getByText("Hard Refresh"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("hard refresh denied");
+  });
+
+  it("shows fallback error message when hard refresh fails with non-Error", async () => {
+    patchMock.mockRejectedValueOnce({ code: 403 });
+    const user = userEvent.setup();
+
+    render(<ArgoHardRefreshMenuItem object={{ getName: () => "demo-app" } as any} extension={extension} />);
+
+    await user.click(screen.getByText("Hard Refresh"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to hard refresh application.");
+  });
+});

--- a/src/renderer/menus/__tests__/argo-application-sync.test.tsx
+++ b/src/renderer/menus/__tests__/argo-application-sync.test.tsx
@@ -53,7 +53,7 @@ describe("ArgoSyncMenuItem", () => {
       },
       "merge",
     );
-    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Sync started for demo-app");
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Sync requested for demo-app");
   });
 
   it("shows endpoint error message when sync fails", async () => {

--- a/src/renderer/menus/__tests__/argo-application-terminate.test.tsx
+++ b/src/renderer/menus/__tests__/argo-application-terminate.test.tsx
@@ -1,3 +1,4 @@
+import { Renderer } from "@freelensapp/extensions";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ArgoTerminateMenuItem } from "../argo-application-terminate";
@@ -13,6 +14,13 @@ jest.mock("../../k8s/argocd", () => ({
 const extension = { name: "argocd-test-extension" } as any;
 
 describe("ArgoTerminateMenuItem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    (Renderer.Component.ConfirmDialog.confirm as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
   it("renders when operation is in progress", () => {
     render(
       <ArgoTerminateMenuItem
@@ -73,5 +81,84 @@ describe("ArgoTerminateMenuItem", () => {
     await user.click(screen.getByText("Terminate Operation"));
 
     expect(patchMock).toHaveBeenCalledWith(expect.any(Object), [{ op: "remove", path: "/operation" }], "json");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows success notification when termination is requested", async () => {
+    patchMock.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <ArgoTerminateMenuItem
+        object={
+          {
+            getName: () => "demo-app",
+            status: {
+              operationState: {
+                phase: "Running",
+              },
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Terminate Operation"));
+
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Terminate requested for demo-app");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows endpoint error message when terminate fails", async () => {
+    patchMock.mockRejectedValueOnce(new Error("terminate denied"));
+    const user = userEvent.setup();
+
+    render(
+      <ArgoTerminateMenuItem
+        object={
+          {
+            getName: () => "demo-app",
+            status: {
+              operationState: {
+                phase: "Running",
+              },
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Terminate Operation"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("terminate denied");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows fallback error message for non-Error failures", async () => {
+    patchMock.mockRejectedValueOnce({ code: 403 });
+    const user = userEvent.setup();
+
+    render(
+      <ArgoTerminateMenuItem
+        object={
+          {
+            getName: () => "demo-app",
+            status: {
+              operationState: {
+                phase: "Running",
+              },
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Terminate Operation"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to terminate operation.");
+    expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/menus/__tests__/argo-rollout-promote.test.tsx
+++ b/src/renderer/menus/__tests__/argo-rollout-promote.test.tsx
@@ -1,4 +1,6 @@
+import { Renderer } from "@freelensapp/extensions";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   ArgoRolloutPromoteFullMenuItem,
   ArgoRolloutPromoteMenuItem,
@@ -18,12 +20,21 @@ jest.mock("../../k8s/rollouts", () => {
   return {
     ...actual,
     getArgoRolloutStore: jest.fn(() => mockStore),
+    __TEST_PROMOTE_PATCH__: mockStore.api.request.patch,
   };
 });
 
 const extension = { name: "argocd-test-extension" } as any;
+const getPromotePatchMock = () => (jest.requireMock("../../k8s/rollouts") as any).__TEST_PROMOTE_PATCH__ as jest.Mock;
 
 describe("ArgoRolloutPromoteMenuItem", () => {
+  beforeEach(() => {
+    getPromotePatchMock().mockReset();
+    getPromotePatchMock().mockResolvedValue({});
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
   it("renders when rollout is in promotable paused state", () => {
     render(
       <ArgoRolloutPromoteMenuItem
@@ -41,6 +52,58 @@ describe("ArgoRolloutPromoteMenuItem", () => {
     );
 
     expect(screen.getByText("Promote")).toBeInTheDocument();
+  });
+
+  it("promotes and shows success notification", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutPromoteMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            getNs: () => "default",
+            spec: { paused: false },
+            status: {
+              phase: "Paused",
+              pauseConditions: [{ reason: "CanaryPauseStep" }],
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Promote"));
+
+    expect(getPromotePatchMock()).toHaveBeenCalled();
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Promote requested for demo-rollout");
+  });
+
+  it("shows fallback message when promotion fails with non-Error", async () => {
+    getPromotePatchMock().mockRejectedValueOnce({ code: 403 });
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutPromoteMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            getNs: () => "default",
+            spec: { paused: false },
+            status: {
+              phase: "Paused",
+              pauseConditions: [{ reason: "CanaryPauseStep" }],
+            },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Promote"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to promote rollout.");
   });
 });
 

--- a/src/renderer/menus/__tests__/argo-rollout-retry.test.tsx
+++ b/src/renderer/menus/__tests__/argo-rollout-retry.test.tsx
@@ -1,3 +1,4 @@
+import { Renderer } from "@freelensapp/extensions";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ArgoRolloutRetryMenuItem } from "../argo-rollout-retry";
@@ -15,6 +16,12 @@ jest.mock("../../k8s/rollouts", () => ({
 const extension = { name: "argocd-test-extension" } as any;
 
 describe("ArgoRolloutRetryMenuItem", () => {
+  beforeEach(() => {
+    patchMock.mockReset();
+    (Renderer.Component.Notifications.ok as jest.Mock).mockReset();
+    (Renderer.Component.Notifications.error as jest.Mock).mockReset();
+  });
+
   it("renders when rollout is degraded", () => {
     render(
       <ArgoRolloutRetryMenuItem
@@ -52,5 +59,48 @@ describe("ArgoRolloutRetryMenuItem", () => {
       },
       "merge",
     );
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Retry requested for rollout");
+  });
+
+  it("shows endpoint error message when retry fails", async () => {
+    patchMock.mockRejectedValueOnce(new Error("retry denied"));
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutRetryMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            status: { phase: "Degraded" },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Retry"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("retry denied");
+  });
+
+  it("shows fallback error message for non-Error failures", async () => {
+    patchMock.mockRejectedValueOnce({ code: 403 });
+    const user = userEvent.setup();
+
+    render(
+      <ArgoRolloutRetryMenuItem
+        object={
+          {
+            getName: () => "demo-rollout",
+            status: { phase: "Degraded" },
+          } as any
+        }
+        extension={extension}
+      />,
+    );
+
+    await user.click(screen.getByText("Retry"));
+
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to retry rollout.");
   });
 });

--- a/src/renderer/menus/argo-application-refresh.tsx
+++ b/src/renderer/menus/argo-application-refresh.tsx
@@ -1,0 +1,73 @@
+import { Renderer } from "@freelensapp/extensions";
+import { withErrorPage } from "../components/error-page";
+import { hardRefreshApplication, refreshApplication } from "../endpoints/argo-application-endpoints";
+import { ArgoApplication, getArgoApplicationStore } from "../k8s/argocd";
+import { runGuardedArgoMutation } from "../mutations";
+
+const {
+  Component: { MenuItem, Icon },
+} = Renderer;
+
+export interface ArgoRefreshMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoApplication> {
+  extension: Renderer.LensExtension;
+}
+
+export interface ArgoHardRefreshMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoApplication> {
+  extension: Renderer.LensExtension;
+}
+
+export const ArgoRefreshMenuItem = (props: ArgoRefreshMenuItemProps) =>
+  withErrorPage(props, () => {
+    const { object, toolbar } = props;
+
+    if (!object) return <></>;
+
+    const store = getArgoApplicationStore();
+
+    const onRefresh = async () => {
+      const appName = object.getName?.() ?? object.metadata?.name ?? "application";
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Refresh",
+        resourceName: appName,
+        run: () => refreshApplication(store, object),
+        successMessage: `Refresh requested for ${appName}`,
+        failureFallback: "Failed to refresh application.",
+      });
+    };
+
+    return (
+      <MenuItem onClick={onRefresh}>
+        <Icon material="refresh" interactive={toolbar} title="Refresh" />
+        <span className="title">Refresh</span>
+      </MenuItem>
+    );
+  });
+
+export const ArgoHardRefreshMenuItem = (props: ArgoHardRefreshMenuItemProps) =>
+  withErrorPage(props, () => {
+    const { object, toolbar } = props;
+
+    if (!object) return <></>;
+
+    const store = getArgoApplicationStore();
+
+    const onHardRefresh = async () => {
+      const appName = object.getName?.() ?? object.metadata?.name ?? "application";
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Hard Refresh",
+        resourceName: appName,
+        run: () => hardRefreshApplication(store, object),
+        successMessage: `Hard refresh requested for ${appName}`,
+        failureFallback: "Failed to hard refresh application.",
+      });
+    };
+
+    return (
+      <MenuItem onClick={onHardRefresh}>
+        <Icon material="autorenew" interactive={toolbar} title="Hard Refresh" />
+        <span className="title">Hard Refresh</span>
+      </MenuItem>
+    );
+  });

--- a/src/renderer/menus/argo-application-refresh.tsx
+++ b/src/renderer/menus/argo-application-refresh.tsx
@@ -66,7 +66,7 @@ export const ArgoHardRefreshMenuItem = (props: ArgoHardRefreshMenuItemProps) =>
 
     return (
       <MenuItem onClick={onHardRefresh}>
-        <Icon material="autorenew" interactive={toolbar} title="Hard Refresh" />
+        <Icon material="downloading" interactive={toolbar} title="Hard Refresh" />
         <span className="title">Hard Refresh</span>
       </MenuItem>
     );

--- a/src/renderer/menus/argo-application-sync.tsx
+++ b/src/renderer/menus/argo-application-sync.tsx
@@ -1,11 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../components/error-page";
 import { syncApplication } from "../endpoints/argo-application-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import { ArgoApplication, getArgoApplicationStore } from "../k8s/argocd";
+import { runGuardedArgoMutation } from "../mutations";
 
 const {
-  Component: { MenuItem, Icon, Notifications },
+  Component: { MenuItem, Icon },
 } = Renderer;
 
 export interface ArgoSyncMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoApplication> {
@@ -22,13 +22,14 @@ export const ArgoSyncMenuItem = (props: ArgoSyncMenuItemProps) =>
 
     const sync = async () => {
       const appName = object.getName?.() ?? object.metadata?.name ?? "application";
-      try {
-        await syncApplication(store, object);
-        Notifications.ok(`Sync started for ${appName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to start sync.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Sync",
+        resourceName: appName,
+        run: () => syncApplication(store, object),
+        successMessage: `Sync requested for ${appName}`,
+        failureFallback: "Failed to start sync.",
+      });
     };
 
     return (

--- a/src/renderer/menus/argo-application-terminate.tsx
+++ b/src/renderer/menus/argo-application-terminate.tsx
@@ -1,11 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../components/error-page";
 import { terminateApplicationOperation } from "../endpoints/argo-application-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import { ArgoApplication, getArgoApplicationStore } from "../k8s/argocd";
+import { runGuardedArgoMutation } from "../mutations";
 
 const {
-  Component: { Icon, MenuItem, Notifications },
+  Component: { Icon, MenuItem },
 } = Renderer;
 
 const terminalPhases = new Set(["Succeeded", "Failed", "Error"]);
@@ -29,13 +29,14 @@ export const ArgoTerminateMenuItem = (props: ArgoTerminateMenuItemProps) =>
 
     const terminateOperation = async () => {
       const appName = object.getName?.() ?? object.metadata?.name ?? "application";
-      try {
-        await terminateApplicationOperation(store, object);
-        Notifications.ok(`Terminate requested for ${appName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to terminate operation.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Terminate",
+        resourceName: appName,
+        run: () => terminateApplicationOperation(store, object),
+        successMessage: `Terminate requested for ${appName}`,
+        failureFallback: "Failed to terminate operation.",
+      });
     };
 
     return (

--- a/src/renderer/menus/argo-rollout-promote.tsx
+++ b/src/renderer/menus/argo-rollout-promote.tsx
@@ -1,7 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../components/error-page";
 import { requestRolloutPromotion } from "../endpoints/argo-rollout-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import {
   type ArgoRollout,
   canShowPromoteAction,
@@ -10,9 +9,10 @@ import {
   canShowPromoteSkipCurrentStepAction,
   getArgoRolloutStore,
 } from "../k8s/rollouts";
+import { runGuardedArgoMutation } from "../mutations";
 
 const {
-  Component: { Icon, MenuItem, Notifications },
+  Component: { Icon, MenuItem },
 } = Renderer;
 
 export interface ArgoRolloutPromoteMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoRollout> {
@@ -45,13 +45,14 @@ export const ArgoRolloutPromoteMenuItem = (props: ArgoRolloutPromoteMenuItemProp
     const rolloutStore = getArgoRolloutStore();
 
     const onPromote = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, {});
-        Notifications.ok(`Promote requested for ${rolloutName(object)}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to promote rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Promote",
+        resourceName: rolloutName(object),
+        run: () => requestRolloutPromotion(rolloutStore, object, {}),
+        successMessage: `Promote requested for ${rolloutName(object)}`,
+        failureFallback: "Failed to promote rollout.",
+      });
     };
 
     return (
@@ -73,13 +74,14 @@ export const ArgoRolloutPromoteFullMenuItem = (props: ArgoRolloutPromoteFullMenu
     const rolloutStore = getArgoRolloutStore();
 
     const onPromoteFull = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { full: true });
-        Notifications.ok(`Full promote requested for ${rolloutName(object)}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to fully promote rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Promote Full",
+        resourceName: rolloutName(object),
+        run: () => requestRolloutPromotion(rolloutStore, object, { full: true }),
+        successMessage: `Full promote requested for ${rolloutName(object)}`,
+        failureFallback: "Failed to fully promote rollout.",
+      });
     };
 
     return (
@@ -101,13 +103,14 @@ export const ArgoRolloutPromoteSkipCurrentMenuItem = (props: ArgoRolloutPromoteS
     const rolloutStore = getArgoRolloutStore();
 
     const onSkipCurrent = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { skipCurrentStep: true });
-        Notifications.ok(`Skip current step requested for ${rolloutName(object)}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to skip current step.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Skip Current Step",
+        resourceName: rolloutName(object),
+        run: () => requestRolloutPromotion(rolloutStore, object, { skipCurrentStep: true }),
+        successMessage: `Skip current step requested for ${rolloutName(object)}`,
+        failureFallback: "Failed to skip current step.",
+      });
     };
 
     return (
@@ -129,13 +132,14 @@ export const ArgoRolloutPromoteSkipAllMenuItem = (props: ArgoRolloutPromoteSkipA
     const rolloutStore = getArgoRolloutStore();
 
     const onSkipAll = async () => {
-      try {
-        await requestRolloutPromotion(rolloutStore, object, { skipAllSteps: true });
-        Notifications.ok(`Skip all steps requested for ${rolloutName(object)}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to skip all steps.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Skip All Steps",
+        resourceName: rolloutName(object),
+        run: () => requestRolloutPromotion(rolloutStore, object, { skipAllSteps: true }),
+        successMessage: `Skip all steps requested for ${rolloutName(object)}`,
+        failureFallback: "Failed to skip all steps.",
+      });
     };
 
     return (

--- a/src/renderer/menus/argo-rollout-retry.tsx
+++ b/src/renderer/menus/argo-rollout-retry.tsx
@@ -1,11 +1,11 @@
 import { Renderer } from "@freelensapp/extensions";
 import { withErrorPage } from "../components/error-page";
 import { retryRollout } from "../endpoints/argo-rollout-endpoints";
-import { getMutationErrorMessage } from "../endpoints/mutation-errors";
 import { type ArgoRollout, canRetryRollout, getArgoRolloutStore } from "../k8s/rollouts";
+import { runGuardedArgoMutation } from "../mutations";
 
 const {
-  Component: { Icon, MenuItem, Notifications },
+  Component: { Icon, MenuItem },
 } = Renderer;
 
 export interface ArgoRolloutRetryMenuItemProps extends Renderer.Component.KubeObjectMenuProps<ArgoRollout> {
@@ -24,13 +24,14 @@ export const ArgoRolloutRetryMenuItem = (props: ArgoRolloutRetryMenuItemProps) =
 
     const handleRetryRollout = async () => {
       const rolloutName = object.getName?.() ?? object.metadata?.name ?? "rollout";
-      try {
-        await retryRollout(rolloutStore, object);
-        Notifications.ok(`Retry requested for ${rolloutName}`);
-      } catch (error) {
-        const message = getMutationErrorMessage(error, "Failed to retry rollout.");
-        Notifications.error(message);
-      }
+      await runGuardedArgoMutation({
+        risk: "low",
+        actionLabel: "Retry",
+        resourceName: rolloutName,
+        run: () => retryRollout(rolloutStore, object),
+        successMessage: `Retry requested for ${rolloutName}`,
+        failureFallback: "Failed to retry rollout.",
+      });
     };
 
     return (

--- a/src/renderer/menus/index.ts
+++ b/src/renderer/menus/index.ts
@@ -1,3 +1,4 @@
+export * from "./argo-application-refresh";
 export * from "./argo-application-sync";
 export * from "./argo-application-terminate";
 export * from "./argo-config-menu";

--- a/src/renderer/mutations/__tests__/guarded-mutation.test.ts
+++ b/src/renderer/mutations/__tests__/guarded-mutation.test.ts
@@ -91,6 +91,25 @@ describe("runGuardedArgoMutation", () => {
     expect(result).toBe("error");
   });
 
+  it("calls onErrorMessage with normalized message", async () => {
+    const run = jest.fn().mockRejectedValue({ code: 403 });
+    const onErrorMessage = jest.fn();
+
+    const result = await runGuardedArgoMutation({
+      risk: "low",
+      actionLabel: "Save",
+      resourceName: "argo-config",
+      run,
+      successMessage: "ArgoCD config saved.",
+      failureFallback: "Failed to save ArgoCD config.",
+      onErrorMessage,
+    });
+
+    expect(onErrorMessage).toHaveBeenCalledWith("Failed to save ArgoCD config.");
+    expect(Renderer.Component.Notifications.error).toHaveBeenCalledWith("Failed to save ArgoCD config.");
+    expect(result).toBe("error");
+  });
+
   it("skips confirmation for low risk mutations", async () => {
     const run = jest.fn().mockResolvedValue(undefined);
 
@@ -99,13 +118,13 @@ describe("runGuardedArgoMutation", () => {
       actionLabel: "Sync",
       resourceName: "demo-app",
       run,
-      successMessage: "Sync started for demo-app",
+      successMessage: "Sync requested for demo-app",
       failureFallback: "Failed to start sync.",
     });
 
     expect(Renderer.Component.ConfirmDialog.confirm).not.toHaveBeenCalled();
     expect(run).toHaveBeenCalledTimes(1);
-    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Sync started for demo-app");
+    expect(Renderer.Component.Notifications.ok).toHaveBeenCalledWith("Sync requested for demo-app");
     expect(result).toBe("success");
   });
 });

--- a/src/renderer/mutations/guarded-mutation.ts
+++ b/src/renderer/mutations/guarded-mutation.ts
@@ -18,6 +18,7 @@ export interface RunGuardedArgoMutationOptions {
   successMessage: string;
   failureFallback: string;
   confirm?: GuardedMutationConfirm;
+  onErrorMessage?: (message: string) => void;
 }
 
 const {
@@ -25,7 +26,7 @@ const {
 } = Renderer;
 
 export async function runGuardedArgoMutation(options: RunGuardedArgoMutationOptions): Promise<GuardedMutationResult> {
-  const { risk, run, successMessage, failureFallback, confirm } = options;
+  const { risk, run, successMessage, failureFallback, confirm, onErrorMessage } = options;
 
   if (risk === "destructive") {
     const isConfirmed = await ConfirmDialog.confirm({
@@ -44,7 +45,9 @@ export async function runGuardedArgoMutation(options: RunGuardedArgoMutationOpti
     Notifications.ok(successMessage);
     return "success";
   } catch (error) {
-    Notifications.error(getMutationErrorMessage(error, failureFallback));
+    const message = getMutationErrorMessage(error, failureFallback);
+    onErrorMessage?.(message);
+    Notifications.error(message);
     return "error";
   }
 }


### PR DESCRIPTION
## Summary
- Add **Refresh** and **Hard Refresh** context menu actions for Argo CD Applications, using annotation-based merge patches (`argocd.argoproj.io/refresh: normal|hard`) via the endpoint layer.
- Migrate remaining mutation handlers to `runGuardedArgoMutation` for consistent notifications and error handling: Application sync/terminate, rollout promote/retry menus, rollout details actions, and config dialog save flow.
- Extend the guarded mutation helper with optional `onErrorMessage` so config dialog can keep inline form errors while reusing shared error normalization.
## User-visible changes
- Application menu now offers: **Refresh → Hard Refresh → Sync → Terminate**
- Hard Refresh uses the `sync_problem` icon to distinguish it from Sync and Refresh
- Abort in rollout details now requires confirmation (aligned with rollout abort menu)
## Technical notes
- Refresh/hard refresh are low-risk, one-click actions (no confirmation dialog)
- Endpoint functions: `refreshApplication`, `hardRefreshApplication`, `buildApplicationRefreshMergePatch`
- Config dialog still shows both toast and inline error on save failure
